### PR TITLE
Fix smoke test waitForReady timeout on cold CI runners

### DIFF
--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -49,9 +49,12 @@ async function doFetch(pathname, { method = 'GET', body, headers = {}, auth = fa
   return res;
 }
 
-async function waitForReady(timeoutMs = 15_000) {
+async function waitForReady(timeoutMs = 60_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    if (serverProc && serverProc.exitCode != null) {
+      throw new Error(`server exited during boot with code ${serverProc.exitCode}`);
+    }
     try {
       const res = await fetch(`${baseUrl}/api/health`);
       if (res.ok) return;
@@ -97,7 +100,7 @@ test('smoke', async (t) => {
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  serverProc.stdout.on('data', () => {});
+  serverProc.stdout.on('data', (b) => process.stderr.write(`[server] ${b}`));
   serverProc.stderr.on('data', (b) => process.stderr.write(`[server] ${b}`));
 
   t.after(async () => {


### PR DESCRIPTION
## Summary
- Diagnosed the failing CI run on `0a59ebc`: `waitForReady` hit its hardcoded 15 s deadline; no `[server] …` stderr appeared because the test was silencing the child's stdout.
- Bumped the deadline to 60 s, piped child stdout through with the `[server]` prefix, and added an early-exit check so a crashed child fails fast with its exit code instead of polling a dead port.

## Test plan
- [x] `DISABLE_OCR=1 npm test` locally — 15/15 sub-tests pass in ~2.9 s
- [ ] Smoke job goes green on this PR

https://claude.ai/code/session_01Cw5zjrG78Coy4utzHA7msX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cw5zjrG78Coy4utzHA7msX)_