### PR TITLE
Configurable site name via admin settings

### DIFF
--- a/admin/dashboard.js
+++ b/admin/dashboard.js
@@ -244,6 +244,41 @@ async function load() {
     document.getElementById('stats').textContent = `Failed to load: ${err.message}`;
   }
   loadBackups();
+  loadSiteSettings();
 }
+
+async function loadSiteSettings() {
+  const input = document.getElementById('site-name-input');
+  if (!input) return;
+  try {
+    const res = await fetch('/api/settings');
+    if (!res.ok) return;
+    const data = await res.json();
+    input.value = data.site_name || '';
+  } catch { /* leave blank */ }
+}
+
+document.getElementById('settings-form')?.addEventListener('submit', async (ev) => {
+  ev.preventDefault();
+  const input = document.getElementById('site-name-input');
+  const status = document.getElementById('settings-status');
+  const value = input.value.trim();
+  if (!value) { status.textContent = 'Site name cannot be empty.'; return; }
+  status.textContent = 'Saving…';
+  try {
+    const res = await fetch('/api/admin/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ site_name: value }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || `HTTP ${res.status}`);
+    }
+    status.textContent = 'Saved. Refresh to see the new branding.';
+  } catch (err) {
+    status.textContent = `Failed: ${err.message}`;
+  }
+});
 
 load();

--- a/admin/equipment.html
+++ b/admin/equipment.html
@@ -69,5 +69,6 @@
     </main>
     <script type="module" src="/admin/equipment.js"></script>
     <script type="module" src="/admin/version.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -78,6 +78,18 @@
       </section>
 
       <section class="section">
+        <h2>Site settings</h2>
+        <form id="settings-form" class="dash-actions" style="gap:0.5rem; align-items:flex-end; flex-wrap:wrap;">
+          <label style="display:flex; flex-direction:column; gap:0.25rem;">
+            <span class="dim" style="font-size:0.85em;">Site name</span>
+            <input id="site-name-input" type="text" maxlength="80" required style="min-width:18rem;" />
+          </label>
+          <button type="submit" class="button-link">Save</button>
+          <span id="settings-status" class="dim"></span>
+        </form>
+      </section>
+
+      <section class="section">
         <h2>Backups</h2>
         <div class="dash-actions" style="margin-bottom: 0.75rem;">
           <button type="button" id="backup-now" class="button-link">Run backup now</button>
@@ -93,5 +105,6 @@
     </main>
     <script type="module" src="/admin/dashboard.js"></script>
     <script type="module" src="/admin/version.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/admin/object.html
+++ b/admin/object.html
@@ -26,5 +26,6 @@
     </main>
     <script type="module" src="/admin/object.js"></script>
     <script type="module" src="/admin/version.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/admin/observations.html
+++ b/admin/observations.html
@@ -65,5 +65,6 @@
     </main>
     <script type="module" src="/admin/observations.js"></script>
     <script type="module" src="/admin/version.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/admin/upload.html
+++ b/admin/upload.html
@@ -200,5 +200,6 @@
     </main>
     <script type="module" src="/admin/upload.js"></script>
     <script type="module" src="/admin/version.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/db/schema.js
+++ b/db/schema.js
@@ -166,6 +166,18 @@ const MIGRATIONS = [
       ALTER TABLE observations ADD COLUMN solved_json TEXT;
     `,
   },
+  {
+    id: 11,
+    name: 'add_site_settings',
+    up: `
+      CREATE TABLE IF NOT EXISTS site_settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT OR IGNORE INTO site_settings (key, value) VALUES ('site_name', 'DeepSkyLog');
+    `,
+  },
 ];
 
 module.exports = { MIGRATIONS };

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -45,5 +45,6 @@
       </div>
     </main>
     <script type="module" src="/js/gallery.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -44,5 +44,6 @@
       </section>
     </main>
     <script type="module" src="/js/dashboard.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/js/site-name.js
+++ b/public/js/site-name.js
@@ -1,0 +1,17 @@
+// Fetches the configured site name and patches the brand label + document
+// title on every page. Loaded as a side-effect from each HTML file.
+
+(async () => {
+  let name;
+  try {
+    const res = await fetch('/api/settings');
+    if (!res.ok) return;
+    const data = await res.json();
+    name = data?.site_name;
+  } catch { return; }
+  if (!name || name === 'DeepSkyLog') return;
+  for (const node of document.querySelectorAll('.brand-name')) {
+    node.textContent = node.textContent.replace(/DeepSkyLog/g, name);
+  }
+  if (document.title) document.title = document.title.replace(/DeepSkyLog/g, name);
+})();

--- a/public/list.html
+++ b/public/list.html
@@ -65,5 +65,6 @@
       </div>
     </main>
     <script type="module" src="/js/list.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/map.html
+++ b/public/map.html
@@ -59,5 +59,6 @@
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
             crossorigin=""></script>
     <script type="module" src="/js/map.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/object.html
+++ b/public/object.html
@@ -29,5 +29,6 @@
             src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js"
             charset="utf-8"></script>
     <script type="module" src="/js/object.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/planner.html
+++ b/public/planner.html
@@ -71,5 +71,6 @@
       </div>
     </main>
     <script type="module" src="/js/planner.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/tonight.html
+++ b/public/tonight.html
@@ -66,5 +66,6 @@
       </div>
     </main>
     <script type="module" src="/js/tonight.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -744,6 +744,34 @@ app.get('/api/admin/config', basicAuth, (_req, res) => {
   res.json({ telescopes: merged });
 });
 
+// Public site settings — site name etc. Read-only, no auth, so every page can
+// fetch it on load to render the configured branding.
+app.get('/api/settings', (_req, res) => {
+  const rows = db.prepare(`SELECT key, value FROM site_settings`).all();
+  const out = { site_name: 'DeepSkyLog' };
+  for (const r of rows) out[r.key] = r.value;
+  res.json(out);
+});
+
+app.put('/api/admin/settings', basicAuth, (req, res) => {
+  const body = req.body || {};
+  const updates = [];
+  if (typeof body.site_name === 'string') {
+    const trimmed = body.site_name.trim();
+    if (!trimmed) return res.status(400).json({ error: 'site_name cannot be empty' });
+    if (trimmed.length > 80) return res.status(400).json({ error: 'site_name max 80 chars' });
+    updates.push(['site_name', trimmed]);
+  }
+  if (!updates.length) return res.status(400).json({ error: 'no settings to update' });
+  const stmt = db.prepare(
+    `INSERT INTO site_settings (key, value, updated_at) VALUES (@key, @value, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+  );
+  const tx = db.transaction((rows) => { for (const [key, value] of rows) stmt.run({ key, value }); });
+  tx(updates);
+  res.json({ ok: true });
+});
+
 app.get('/api/admin/equipment', basicAuth, (_req, res) => {
   const rows = db
     .prepare(`SELECT * FROM equipment ORDER BY retired ASC, kind, name`)


### PR DESCRIPTION
## Summary
- New `site_settings(key, value)` table (migration 11), seeded with `site_name = 'DeepSkyLog'`
- Public `GET /api/settings` returns the current name; admin `PUT /api/admin/settings` updates it
- `/js/site-name.js` (loaded on every public + admin page) patches `.brand-name` and the `<title>` after fetching the configured name
- Admin dashboard gains a "Site settings" form to edit it

## Test plan
- [x] `npm test` (smoke) green: 15/15
- [ ] Manual: open `/admin/`, change the name, refresh public site to confirm new branding


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_