### PR TITLE
Upload: surface EXIF GPS, allow override

### DIFF
--- a/admin/upload.html
+++ b/admin/upload.html
@@ -85,6 +85,21 @@
               </label>
             </div>
 
+            <div class="row">
+              <label class="field">
+                <span>Latitude</span>
+                <input id="latitude-input" name="latitude" type="number" step="0.0001" min="-90" max="90" placeholder="51.4769" />
+              </label>
+              <label class="field">
+                <span>Longitude</span>
+                <input id="longitude-input" name="longitude" type="number" step="0.0001" min="-180" max="180" placeholder="-0.0005" />
+              </label>
+              <label class="field" style="flex:0 0 auto; align-self:flex-end;">
+                <span>&nbsp;</span>
+                <button type="button" id="use-image-gps" class="button-link ghost-link" disabled title="Copy GPS from the image's EXIF">Use image GPS</button>
+              </label>
+            </div>
+
             <label class="field">
               <span>Telescope</span>
               <select id="telescope-select" name="telescope" required>

--- a/admin/upload.js
+++ b/admin/upload.js
@@ -20,6 +20,9 @@ const catalogInput = document.getElementById('catalog-input');
 const catalogNumberInput = document.getElementById('catalog-number-input');
 const dateInput = document.getElementById('date-input');
 const locationInput = document.getElementById('location-input');
+const latitudeInput = document.getElementById('latitude-input');
+const longitudeInput = document.getElementById('longitude-input');
+const useImageGpsBtn = document.getElementById('use-image-gps');
 const titleInput = document.getElementById('title-input');
 const telescopeSelect = document.getElementById('telescope-select');
 const telescopeHint = document.getElementById('telescope-hint');
@@ -281,6 +284,18 @@ function onStaged(res) {
     : toLocalDatetimeValue(null);
   updateMoonPreview();
 
+  // GPS: enable the "Use image GPS" button when EXIF has coords, and pre-fill
+  // the lat/lon inputs only if the user hasn't typed something already.
+  const hasGps = typeof res.exif?.latitude === 'number' && typeof res.exif?.longitude === 'number';
+  useImageGpsBtn.disabled = !hasGps;
+  if (hasGps) {
+    useImageGpsBtn.title = `Use image GPS (${res.exif.latitude.toFixed(4)}, ${res.exif.longitude.toFixed(4)})`;
+    if (!latitudeInput.value) latitudeInput.value = res.exif.latitude.toFixed(6);
+    if (!longitudeInput.value) longitudeInput.value = res.exif.longitude.toFixed(6);
+  } else {
+    useImageGpsBtn.title = 'No GPS in image EXIF';
+  }
+
   const metaSource = res.kind === 'fits' ? 'FITS header' : 'EXIF';
   if (res.telescope_match) {
     telescopeSelect.value = res.telescope_match;
@@ -398,6 +413,10 @@ function resetForm() {
   objectHint.textContent = '';
   telescopeHint.textContent = '';
   moonDisplay.value = '';
+  latitudeInput.value = '';
+  longitudeInput.value = '';
+  useImageGpsBtn.disabled = true;
+  useImageGpsBtn.title = 'No GPS in image EXIF';
   seestarJsonField.value = '';
   sidecarSummary.textContent = 'Optional. Drop the .json file Seestar saves alongside the image and stack count, exposure, gain and filter all auto-fill. Without it we read EXIF and OCR the watermark band.';
   setStatus('');
@@ -405,6 +424,14 @@ function resetForm() {
 
 dateInput.addEventListener('change', updateMoonPreview);
 dateInput.addEventListener('input', updateMoonPreview);
+
+useImageGpsBtn.addEventListener('click', () => {
+  const lat = currentStage?.exif?.latitude;
+  const lon = currentStage?.exif?.longitude;
+  if (typeof lat !== 'number' || typeof lon !== 'number') return;
+  latitudeInput.value = lat.toFixed(6);
+  longitudeInput.value = lon.toFixed(6);
+});
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -432,6 +459,8 @@ form.addEventListener('submit', async (e) => {
     gain: gainInput.value || null,
     filter_name: filterInput.value.trim() || null,
     seestar_json: seestarJsonField.value || null,
+    latitude: latitudeInput.value !== '' ? Number(latitudeInput.value) : null,
+    longitude: longitudeInput.value !== '' ? Number(longitudeInput.value) : null,
   };
 
   if (!payload.telescope) {

--- a/server.js
+++ b/server.js
@@ -1336,6 +1336,12 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
   const formIso = body.iso != null && body.iso !== ''
     ? Number(body.iso) : null;
 
+  // Form lat/lon (clamped) take precedence over anything we mine from EXIF.
+  const formLatitude = body.latitude != null && body.latitude !== ''
+    ? clamp(body.latitude, -90, 90) : null;
+  const formLongitude = body.longitude != null && body.longitude !== ''
+    ? clamp(body.longitude, -180, 180) : null;
+
   const rawObjectId = body.object_id ? Number(body.object_id) : null;
   let matchedObject = null;
   if (rawObjectId) {
@@ -1422,8 +1428,12 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
   }
 
   const fx = fitsHeader ? fitsExif(fitsHeader) : null;
-  const latitude = fx?.latitude ?? (typeof exif?.latitude === 'number' ? exif.latitude : null);
-  const longitude = fx?.longitude ?? (typeof exif?.longitude === 'number' ? exif.longitude : null);
+  const latitude = formLatitude
+    ?? fx?.latitude
+    ?? (typeof exif?.latitude === 'number' ? exif.latitude : null);
+  const longitude = formLongitude
+    ?? fx?.longitude
+    ?? (typeof exif?.longitude === 'number' ? exif.longitude : null);
 
   const cameraField = fx?.device || (exif?.Model ? String(exif.Model) : null);
   const exposureField = exif?.ExposureTime ?? fx?.exposureSeconds ?? null;


### PR DESCRIPTION
## Summary
- New `latitude` / `longitude` inputs on the upload form
- Pre-filled from EXIF on stage; "Use image GPS" button copies the parsed coords on demand (disabled when EXIF has none)
- Server prefers explicit form lat/lon over EXIF/FITS values, clamped to ±90 / ±180

## Test plan
- [x] `npm test` (smoke) green: 15/15
- [ ] Manual: upload a Seestar JPG with GPS → fields auto-populate; click button to overwrite manual edits
- [ ] Manual: upload a JPG without GPS → button disabled, fields remain empty unless typed


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_