### PR TITLE
Comets: free-form object type with per-observation RA/Dec

### DIFF
--- a/admin/upload.html
+++ b/admin/upload.html
@@ -68,6 +68,38 @@
                 <span>Catalog #</span>
                 <input id="catalog-number-input" name="catalog_number" placeholder="42" />
               </label>
+              <label class="field">
+                <span>Object type</span>
+                <select id="object-type-input" name="object_type">
+                  <option value="">— auto —</option>
+                  <option value="GAL">Galaxy</option>
+                  <option value="GC">Globular Cluster</option>
+                  <option value="OC">Open Cluster</option>
+                  <option value="PN">Planetary Nebula</option>
+                  <option value="DN">Diffuse Nebula</option>
+                  <option value="SNR">Supernova Remnant</option>
+                  <option value="MW">Star Cloud</option>
+                  <option value="AST">Asterism</option>
+                  <option value="DS">Double Star</option>
+                  <option value="STAR">Star</option>
+                  <option value="MOON">Moon</option>
+                  <option value="PLAN">Planet</option>
+                  <option value="COMET">Comet</option>
+                </select>
+                <small class="dim">Required for comets and other objects not in a seeded list.</small>
+              </label>
+            </div>
+
+            <div class="row" id="ra-dec-row">
+              <label class="field">
+                <span>RA (hours)</span>
+                <input id="ra-hours-input" name="ra_hours" type="number" step="0.0001" min="0" max="24" placeholder="e.g. 5.5878" />
+              </label>
+              <label class="field">
+                <span>Dec (°)</span>
+                <input id="dec-degrees-input" name="dec_degrees" type="number" step="0.0001" min="-90" max="90" placeholder="e.g. -5.391" />
+              </label>
+              <small class="dim" style="flex-basis:100%;">Per-observation sky position. Useful for comets and other moving targets.</small>
             </div>
 
             <label class="field">

--- a/admin/upload.js
+++ b/admin/upload.js
@@ -20,6 +20,9 @@ const catalogInput = document.getElementById('catalog-input');
 const catalogNumberInput = document.getElementById('catalog-number-input');
 const dateInput = document.getElementById('date-input');
 const locationInput = document.getElementById('location-input');
+const objectTypeInput = document.getElementById('object-type-input');
+const raHoursInput = document.getElementById('ra-hours-input');
+const decDegreesInput = document.getElementById('dec-degrees-input');
 const latitudeInput = document.getElementById('latitude-input');
 const longitudeInput = document.getElementById('longitude-input');
 const useImageGpsBtn = document.getElementById('use-image-gps');
@@ -544,6 +547,9 @@ form.addEventListener('submit', async (e) => {
     seestar_json: seestarJsonField.value || null,
     latitude: latitudeInput.value !== '' ? Number(latitudeInput.value) : null,
     longitude: longitudeInput.value !== '' ? Number(longitudeInput.value) : null,
+    object_type: objectTypeInput.value || null,
+    ra_hours: raHoursInput.value !== '' ? Number(raHoursInput.value) : null,
+    dec_degrees: decDegreesInput.value !== '' ? Number(decDegreesInput.value) : null,
   };
 
   if (!payload.telescope) {

--- a/db/schema.js
+++ b/db/schema.js
@@ -178,6 +178,15 @@ const MIGRATIONS = [
       INSERT OR IGNORE INTO site_settings (key, value) VALUES ('site_name', 'DeepSkyLog');
     `,
   },
+  {
+    id: 12,
+    name: 'add_observation_object_type_and_coords',
+    up: `
+      ALTER TABLE observations ADD COLUMN object_type TEXT;
+      ALTER TABLE observations ADD COLUMN ra_hours REAL;
+      ALTER TABLE observations ADD COLUMN dec_degrees REAL;
+    `,
+  },
 ];
 
 module.exports = { MIGRATIONS };

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -54,6 +54,7 @@ export const OBJECT_TYPES = {
   STAR: 'Star',
   MOON: 'Moon',
   PLAN: 'Planet',
+  COMET: 'Comet',
 };
 
 export function typeLabel(code) {

--- a/server.js
+++ b/server.js
@@ -365,7 +365,9 @@ app.get('/api/observations', (req, res) => {
     params.telescope = telescope;
   }
   if (objectType) {
-    clauses.push('lo.object_type = @object_type');
+    // Match against the catalog row's type when linked, otherwise the
+    // free-form type stored on the observation itself (used for comets).
+    clauses.push('COALESCE(lo.object_type, o.object_type) = @object_type');
     params.object_type = objectType;
   }
   if (hasImage) {
@@ -376,7 +378,9 @@ app.get('/api/observations', (req, res) => {
   const rows = db
     .prepare(
       `SELECT o.*, lo.catalog AS object_catalog, lo.catalog_number AS object_catalog_number,
-              lo.name AS object_name, lo.object_type AS object_type, lo.constellation AS constellation
+              lo.name AS object_name,
+              COALESCE(lo.object_type, o.object_type) AS object_type,
+              lo.constellation AS constellation
          FROM observations o
          LEFT JOIN list_objects lo ON lo.id = o.object_id
          ${where}
@@ -639,11 +643,18 @@ app.get('/api/filters', (_req, res) => {
     .all()
     .map((r) => r.telescope);
 
+  // Object types come from both the catalog (list_objects) and the
+  // free-form types stored directly on observations (e.g. comets), so
+  // filtering picks up entries that aren't in any seeded list.
   const objectTypes = db
     .prepare(
-      `SELECT DISTINCT object_type FROM list_objects
-         WHERE object_type IS NOT NULL AND object_type != ''
-         ORDER BY object_type`,
+      `SELECT DISTINCT object_type FROM (
+         SELECT object_type FROM list_objects
+         UNION
+         SELECT object_type FROM observations
+       )
+       WHERE object_type IS NOT NULL AND object_type != ''
+       ORDER BY object_type`,
     )
     .all()
     .map((r) => r.object_type);
@@ -1364,6 +1375,16 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
   const formIso = body.iso != null && body.iso !== ''
     ? Number(body.iso) : null;
 
+  // Free-form object metadata for observations not backed by a list row
+  // (notably comets, which don't fit the static catalog model).
+  const allowedTypes = ['GC','OC','PN','SNR','DN','GAL','MW','AST','DS','STAR','MOON','PLAN','COMET'];
+  const observationObjectType = (typeof body.object_type === 'string' && allowedTypes.includes(body.object_type))
+    ? body.object_type : null;
+  const observationRaHours = body.ra_hours != null && body.ra_hours !== ''
+    ? clamp(body.ra_hours, 0, 24) : null;
+  const observationDecDegrees = body.dec_degrees != null && body.dec_degrees !== ''
+    ? clamp(body.dec_degrees, -90, 90) : null;
+
   // Form lat/lon (clamped) take precedence over anything we mine from EXIF.
   const formLatitude = body.latitude != null && body.latitude !== ''
     ? clamp(body.latitude, -90, 90) : null;
@@ -1475,12 +1496,14 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
         location, telescope, camera, exposure_seconds, iso, focal_length_mm,
         aperture, image_path, thumbnail_path, exif_json, rating,
         latitude, longitude, seeing, transparency, moon_phase,
-        moon_phase_name, bortle, stack_count, gain, filter_name, device_json)
+        moon_phase_name, bortle, stack_count, gain, filter_name, device_json,
+        object_type, ra_hours, dec_degrees)
      VALUES (@object_id, @catalog, @catalog_number, @title, @description, @observed_at,
              @location, @telescope, @camera, @exposure_seconds, @iso, @focal_length_mm,
              @aperture, @image_path, @thumbnail_path, @exif_json, @rating,
              @latitude, @longitude, @seeing, @transparency, @moon_phase,
-             @moon_phase_name, @bortle, @stack_count, @gain, @filter_name, @device_json)`,
+             @moon_phase_name, @bortle, @stack_count, @gain, @filter_name, @device_json,
+             @object_type, @ra_hours, @dec_degrees)`,
   );
 
   const completeList = db.prepare(
@@ -1519,6 +1542,9 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
       gain,
       filter_name: filterName,
       device_json: deviceJson,
+      object_type: observationObjectType,
+      ra_hours: observationRaHours,
+      dec_degrees: observationDecDegrees,
     });
 
     const observationId = Number(result.lastInsertRowid);
@@ -1613,6 +1639,13 @@ app.patch('/api/admin/observations/:id', basicAuth, (req, res) => {
   if ('aperture' in body)         updates.aperture = num(body.aperture);
   if ('latitude' in body)         updates.latitude  = clamp(body.latitude, -90, 90);
   if ('longitude' in body)        updates.longitude = clamp(body.longitude, -180, 180);
+  if ('object_type' in body) {
+    const allowed = ['GC','OC','PN','SNR','DN','GAL','MW','AST','DS','STAR','MOON','PLAN','COMET'];
+    updates.object_type = (typeof body.object_type === 'string' && allowed.includes(body.object_type))
+      ? body.object_type : null;
+  }
+  if ('ra_hours' in body)         updates.ra_hours = clamp(body.ra_hours, 0, 24);
+  if ('dec_degrees' in body)      updates.dec_degrees = clamp(body.dec_degrees, -90, 90);
 
   // observed_at: accept null (clear) or a parseable date; reject obvious
   // garbage so the column doesn't fill up with whatever the client sent.


### PR DESCRIPTION
## Summary
- New `COMET` entry in `OBJECT_TYPES` (gallery/planner/etc. label it)
- Migration 12 adds `object_type`, `ra_hours`, `dec_degrees` columns to `observations` so free-form objects (notably comets) can record their type and sky position without needing a list row
- Upload form gains an "Object type" select and RA/Dec inputs
- Server stores them on insert and on PATCH; `/api/observations` filters on `COALESCE(list_object.type, observation.type)` so the existing `object_type=COMET` filter picks up free-form comets
- `/api/filters` merges types from both `list_objects` and `observations`

## Test plan
- [x] `npm test` (smoke) green: 15/15
- [ ] Manual: log a comet observation with object_type=COMET + RA/Dec, verify it appears in the gallery filtered by Comet


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_