### PR TITLE
Tests: cover the 5 shipped features; backlog HTML/E2E follow-ups

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -43,6 +43,22 @@ Items prefixed with ✅ are shipped on `main`; the others are still open.
     single upload ticks every list the target appears on. **Still missing:**
     the full Herschel 400 and SAC 110 Best of NGC.
 
+## Test coverage to add
+
+12. **HTML wiring smoke checks** — boot the server in CI, `curl` every public
+    and admin HTML page, grep for the IDs each page module expects
+    (`#latitude-input`, `#site-name-input`, `#object-type-input`, the
+    `/js/site-name.js` script tag, etc.). Catches typos in form-field IDs
+    that today only fail in the browser. ~30 min to add as a new sub-test
+    in `test/smoke.test.js`.
+13. **Headless browser tests (Playwright)** — drive the actual upload flow:
+    drop multiple files, fill the form, click "Use image GPS", change the
+    site name and verify the brand label updates after a refresh, log a
+    comet observation and confirm it appears under the COMET filter on the
+    gallery page. Requires adding `@playwright/test` as a dev dependency,
+    a `tests/e2e/` folder, and a CI job that installs the browser binaries.
+    1–2 hours of scaffolding for the first test, then minutes per scenario.
+
 ## Bonus shipped (not in original backlog)
 
 - ✅ **Edit observations** — PATCH endpoint + admin modal form.

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -332,6 +332,203 @@ test('smoke', async (t) => {
     }
   });
 
+  await t.test('site settings: default name, PUT updates, public GET reflects', async () => {
+    const initial = await fetchJsonAuthed('/api/settings');
+    assert.equal(initial.site_name, 'DeepSkyLog');
+
+    const update = await fetch(`${baseUrl}/api/admin/settings`, {
+      method: 'PUT',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ site_name: 'My Backyard Sky' }),
+    });
+    assert.equal(update.status, 200);
+
+    const after = await (await fetch(`${baseUrl}/api/settings`)).json();
+    assert.equal(after.site_name, 'My Backyard Sky');
+
+    // Empty / oversized values are rejected.
+    const empty = await fetch(`${baseUrl}/api/admin/settings`, {
+      method: 'PUT',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ site_name: '   ' }),
+    });
+    assert.equal(empty.status, 400);
+
+    // Restore default so the rest of the suite isn't surprised.
+    await fetch(`${baseUrl}/api/admin/settings`, {
+      method: 'PUT',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ site_name: 'DeepSkyLog' }),
+    });
+  });
+
+  await t.test('planner accepts explicit start/end window', async () => {
+    const start = new Date();
+    start.setUTCHours(20, 0, 0, 0);
+    const end = new Date(start.getTime() + 6 * 3_600_000);
+    const data = await fetchJsonAuthed(
+      `/api/planner?lat=51.5&lon=0&min_alt=10&start=${encodeURIComponent(start.toISOString())}&end=${encodeURIComponent(end.toISOString())}`,
+    );
+    assert.equal(data.window.start, start.toISOString());
+    assert.equal(data.window.end, end.toISOString());
+
+    // Reversed window is rejected.
+    const bad = await fetch(
+      `${baseUrl}/api/planner?lat=51.5&lon=0&start=${encodeURIComponent(end.toISOString())}&end=${encodeURIComponent(start.toISOString())}`,
+    );
+    assert.equal(bad.status, 400);
+  });
+
+  await t.test('upload: explicit form lat/lon override EXIF GPS', async () => {
+    const jpeg = await buildSyntheticJpeg();
+    const fd = new FormData();
+    fd.set('image', new Blob([jpeg], { type: 'image/jpeg' }), 'm51.jpg');
+    const stage = await fetch(`${baseUrl}/api/admin/stage`, {
+      method: 'POST',
+      headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },
+      body: fd,
+    }).then((r) => r.json());
+
+    const messier = await fetchJsonAuthed('/api/lists/messier');
+    const m51 = messier.objects.find((o) => o.catalog_number === '51');
+    assert.ok(m51);
+
+    const created = await fetch(`${baseUrl}/api/admin/observations`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        stage_id: stage.stage_id,
+        object_id: m51.id, catalog: 'M', catalog_number: '51',
+        object_name: 'Whirlpool', telescope: 'Seestar S30 Pro',
+        observed_at: '2026-04-19T22:00',
+        latitude: 51.4769, longitude: -0.0005,
+      }),
+    }).then((r) => r.json());
+
+    // Finalize returns just {id, paths}; pull the full row to verify storage.
+    const all = await (await fetch(`${baseUrl}/api/observations`)).json();
+    const row = all.find((o) => o.id === created.id);
+    assert.ok(row, 'created row visible from /api/observations');
+    assert.equal(row.latitude, 51.4769);
+    assert.equal(row.longitude, -0.0005);
+
+    // Out-of-range form values are clamped, not rejected.
+    const fd2 = new FormData();
+    fd2.set('image', new Blob([jpeg], { type: 'image/jpeg' }), 'm51b.jpg');
+    const stage2 = await fetch(`${baseUrl}/api/admin/stage`, {
+      method: 'POST',
+      headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },
+      body: fd2,
+    }).then((r) => r.json());
+    const clamped = await fetch(`${baseUrl}/api/admin/observations`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        stage_id: stage2.stage_id,
+        object_id: m51.id, catalog: 'M', catalog_number: '51',
+        object_name: 'Whirlpool', telescope: 'Seestar S30 Pro',
+        observed_at: '2026-04-19T22:00',
+        latitude: 999, longitude: -999,
+      }),
+    }).then((r) => r.json());
+    const all2 = await (await fetch(`${baseUrl}/api/observations`)).json();
+    const clampedRow = all2.find((o) => o.id === clamped.id);
+    assert.equal(clampedRow.latitude, 90);
+    assert.equal(clampedRow.longitude, -180);
+  });
+
+  await t.test('comet observation: object_type + RA/Dec persist, filterable', async () => {
+    const jpeg = await buildSyntheticJpeg();
+    const fd = new FormData();
+    fd.set('image', new Blob([jpeg], { type: 'image/jpeg' }), 'comet.jpg');
+    const stage = await fetch(`${baseUrl}/api/admin/stage`, {
+      method: 'POST',
+      headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },
+      body: fd,
+    }).then((r) => r.json());
+
+    const created = await fetch(`${baseUrl}/api/admin/observations`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        stage_id: stage.stage_id,
+        object_name: 'C/2023 A3 Tsuchinshan-ATLAS',
+        telescope: 'Seestar S30 Pro',
+        observed_at: '2026-04-19T22:00',
+        object_type: 'COMET',
+        ra_hours: 14.25,
+        dec_degrees: -2.5,
+      }),
+    }).then((r) => r.json());
+
+    // /api/observations?object_type=COMET should pick it up via the
+    // COALESCE(list_object.type, observation.type) filter, and the row
+    // should carry the values we sent through.
+    const filtered = await (await fetch(`${baseUrl}/api/observations?object_type=COMET`)).json();
+    const row = filtered.find((o) => o.id === created.id);
+    assert.ok(row, 'comet observation visible under object_type=COMET');
+    assert.equal(row.object_type, 'COMET');
+    assert.equal(row.ra_hours, 14.25);
+    assert.equal(row.dec_degrees, -2.5);
+
+    // /api/filters surfaces COMET as a valid type from observations.
+    const filters = await (await fetch(`${baseUrl}/api/filters`)).json();
+    assert.ok(filters.objectTypes.includes('COMET'), 'COMET present in filters');
+
+    // Garbage object_type is silently dropped to null on PATCH (not 500).
+    const patched = await fetch(`${baseUrl}/api/admin/observations/${created.id}`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ object_type: 'BOGUS' }),
+    }).then((r) => r.json());
+    assert.equal(patched.object_type, null);
+  });
+
+  await t.test('batch staging: many parallel stages succeed independently', async () => {
+    const auth = { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') };
+    const stages = await Promise.all(
+      [0, 1, 2].map(async (i) => {
+        const jpeg = await buildSyntheticJpeg();
+        const fd = new FormData();
+        fd.set('image', new Blob([jpeg], { type: 'image/jpeg' }), `batch-${i}.jpg`);
+        const res = await fetch(`${baseUrl}/api/admin/stage`, { method: 'POST', headers: auth, body: fd });
+        assert.equal(res.status, 201);
+        return res.json();
+      }),
+    );
+    const ids = new Set(stages.map((s) => s.stage_id));
+    assert.equal(ids.size, 3, 'each stage got a distinct id');
+
+    // Drop them — exercises the stage DELETE path used by the batch cancel.
+    for (const s of stages) {
+      const del = await fetch(`${baseUrl}/api/admin/stage/${encodeURIComponent(s.stage_id)}`, {
+        method: 'DELETE', headers: auth,
+      });
+      assert.equal(del.status, 204);
+    }
+  });
+
   // Run last — consumes the per-IP failure budget, so any admin call after
   // this one gets a 429 until the 15-minute window rolls over.
   await t.test('rate limit triggers 429 after 20 failures', async () => {


### PR DESCRIPTION
## Summary
Adds smoke tests for the five features merged in PRs #31–#35 and parks HTML/E2E coverage on the backlog.

New sub-tests in `test/smoke.test.js`:
- `site_settings`: default name, `PUT /api/admin/settings` updates, public `GET /api/settings` reflects, empty/whitespace rejected
- `/api/planner` accepts explicit `start`/`end` window; reversed window → 400
- Upload finalize: explicit form `latitude`/`longitude` override EXIF and clamp at ±90 / ±180
- Comet observation: `object_type=COMET` + `ra_hours` + `dec_degrees` persist; `/api/observations?object_type=COMET` picks them up via the `COALESCE` filter; `/api/filters` surfaces `COMET`; `PATCH` with a bogus `object_type` drops to null instead of erroring
- Batch staging: parallel `POST /api/admin/stage` calls return distinct ids; stage `DELETE` cleans up

Backlog additions:
- #12 HTML wiring smoke checks (curl + grep) — ~30 min
- #13 Playwright e2e — ~1–2 h scaffolding

## Test plan
- [x] `npm test` (smoke) green: 20/20 (was 15/15)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_