### PR TITLE
Upload: parse Seestar export filenames as a metadata fallback

### DIFF
--- a/admin/upload.js
+++ b/admin/upload.js
@@ -386,6 +386,16 @@ function onStaged(res) {
     exposureInput.value = totalExposure;
   }
 
+  // Stack count and filter name come from the Seestar filename pattern
+  // (Stacked_<count>_..._<filter>_..._<ts>) when EXIF/sidecar didn't
+  // already provide them.
+  if (res.exif?.stack_count != null && !stackCountInput.value) {
+    stackCountInput.value = res.exif.stack_count;
+  }
+  if (res.exif?.filter_name && !filterInput.value) {
+    filterInput.value = res.exif.filter_name;
+  }
+
   // Photographer: not a form field today, so just surface it in the EXIF
   // table by appending a row.
   if (res.guesses?.photographer) {

--- a/lib/seestar_meta.js
+++ b/lib/seestar_meta.js
@@ -85,6 +85,33 @@ function parsePhotographer(text) {
   return null;
 }
 
+// Seestar export filenames are highly structured, e.g.
+//   Stacked_206_C 4_10.0s_IRCUT_20241027-213334.jpg
+//   Light_206_M 31_30.0s_LP_20240901-021500.fits
+// Decoded:
+//   <kind>_<count>_<target>_<sub_exposure>s_<filter>_<YYYYMMDD>-<HHMMSS>
+// Older firmware sometimes drops the count or the filter; we accept those.
+function parseFilename(name) {
+  if (!name) return null;
+  const base = String(name).replace(/\.[a-z0-9]+$/i, '');
+  const m = base.match(
+    /^(?:Stacked|Light(?:\s*Frame)?)_(?:(\d+)_)?(.+?)_([\d.]+)s(?:_([A-Za-z0-9._-]+))?_(\d{8})-(\d{6})$/i,
+  );
+  if (!m) return null;
+  const [, count, target, exp, filter, ymd, hms] = m;
+  const captured_at =
+    `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}T` +
+    `${hms.slice(0, 2)}:${hms.slice(2, 4)}:${hms.slice(4, 6)}`;
+  return {
+    stack_count: count ? Number(count) : null,
+    target: parseTarget(target),
+    target_raw: target.trim(),
+    exposure_seconds: Number(exp),
+    filter_name: filter || null,
+    captured_at,
+  };
+}
+
 // One-stop helper: run all parsers and return whatever we found.
 function parseAll(text) {
   return {
@@ -102,5 +129,6 @@ module.exports = {
   parseCoords,
   parseCaptureDate,
   parsePhotographer,
+  parseFilename,
   parseAll,
 };

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ const { altAz, moonPhase } = require('./lib/astro');
 const { bodyPosition } = require('./lib/ephemeris');
 const { isFitsPath, readFitsHeader, renderFitsJpeg, fitsExif } = require('./lib/fits');
 const { ocrBanner } = require('./lib/seestar_ocr');
-const { parseAll: parseSeestarText } = require('./lib/seestar_meta');
+const { parseAll: parseSeestarText, parseFilename: parseSeestarFilename } = require('./lib/seestar_meta');
 const astrometry = require('./lib/astrometry');
 
 const PORT = Number(process.env.PORT) || 3000;
@@ -1269,6 +1269,21 @@ app.post('/api/admin/stage', basicAuth, stageUpload.single('image'), async (req,
   const combinedText = [exifTextBlob || '', ocrText || ''].filter(Boolean).join('\n');
   const guesses = parseSeestarText(combinedText);
 
+  // Seestar export filenames carry stack count, target, sub-exposure,
+  // filter, and capture timestamp — fill any gaps left by EXIF/OCR.
+  const fileGuess = parseSeestarFilename(req.file.originalname);
+  let stackCount = null;
+  let filterName = null;
+  if (fileGuess) {
+    if (!capturedIso && fileGuess.captured_at) capturedIso = fileGuess.captured_at;
+    if (!objectName && fileGuess.target?.raw) objectName = fileGuess.target.raw;
+    if (exposureSeconds == null && fileGuess.exposure_seconds != null) {
+      exposureSeconds = fileGuess.exposure_seconds;
+    }
+    stackCount = fileGuess.stack_count;
+    filterName = fileGuess.filter_name;
+  }
+
   // Promote OCR/EXIF guesses into the exposed exif block where the form
   // currently has nothing (sub-second EXIF exposure shouldn't be clobbered
   // by a watermark "52min", which is total integration; we put that in a
@@ -1295,12 +1310,15 @@ app.post('/api/admin/stage', basicAuth, stageUpload.single('image'), async (req,
       focal_length_mm: focalLength,
       aperture,
       object_name: objectName,
+      stack_count: stackCount,
+      filter_name: filterName,
     },
     guesses: {
-      target: guesses.target || null,
+      target: guesses.target || fileGuess?.target || null,
       total_exposure_seconds: guesses.exposure_seconds_total,
       photographer: guesses.photographer,
       from_ocr: !!ocrText,
+      from_filename: !!fileGuess,
       ocr_error: ocrError,
     },
     telescope_match: telescopeMatch,

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -505,6 +505,26 @@ test('smoke', async (t) => {
     assert.equal(patched.object_type, null);
   });
 
+  await t.test('Seestar filename parser fills gaps in stage response', async () => {
+    const auth = { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') };
+    const jpeg = await buildSyntheticJpeg();
+    const fd = new FormData();
+    fd.set('image', new Blob([jpeg], { type: 'image/jpeg' }),
+      'Stacked_206_C 4_10.0s_IRCUT_20241027-213334.jpg');
+    const res = await fetch(`${baseUrl}/api/admin/stage`, { method: 'POST', headers: auth, body: fd });
+    assert.equal(res.status, 201);
+    const staged = await res.json();
+    assert.equal(staged.exif.stack_count, 206);
+    assert.equal(staged.exif.filter_name, 'IRCUT');
+    assert.equal(staged.exif.exposure_seconds, 10);
+    assert.equal(staged.exif.captured_at, '2024-10-27T21:33:34');
+    assert.equal(staged.exif.object_name, 'C4');
+    assert.equal(staged.guesses.from_filename, true);
+    await fetch(`${baseUrl}/api/admin/stage/${encodeURIComponent(staged.stage_id)}`, {
+      method: 'DELETE', headers: auth,
+    });
+  });
+
   await t.test('batch staging: many parallel stages succeed independently', async () => {
     const auth = { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') };
     const stages = await Promise.all(


### PR DESCRIPTION
## Summary
The Seestar app names exports as `Stacked_<count>_<target>_<sub>s_<filter>_<YYYYMMDD>-<HHMMSS>.<ext>` — e.g. `Stacked_206_C 4_10.0s_IRCUT_20241027-213334.jpg`. That string carries five form fields, and now we use them.

- New `parseFilename` in `lib/seestar_meta.js` (regex anchored on the date-time tail, count + filter optional for older firmware)
- Stage endpoint fills gaps EXIF/OCR didn't cover: capture date, target, sub exposure
- Stage response now includes `exif.stack_count` and `exif.filter_name` so the upload form pre-fills them
- `guesses.from_filename` flag for diagnostics
- Smoke test parses the exact filename from the user's example: `206`, `IRCUT`, `10s`, `2024-10-27T21:33:34`, `C4`

## Test plan
- [x] `npm test` (smoke) green: 21/21 (was 20/20)
- [ ] Manual: drop a Seestar JPG, confirm stack count + filter + sub-exposure auto-populate


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_