### PR TITLE
Public observation detail page (map + moon SVG + prev/next siblings)

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -45,7 +45,12 @@ function galleryItem(obs) {
 
   return el(
     'a',
-    { class: 'gallery-item', href: obs.object_id ? `/object.html?id=${obs.object_id}` : '#' },
+    { class: 'gallery-item',
+      // Drill into the per-observation detail page for every row. The id
+      // is always present; the previous fallback to /object.html?id=…
+      // (or '#' for free-form rows) lost half the metadata and the moon
+      // and map panels.
+      href: obs.id ? `/observation.html?id=${obs.id}` : '#' },
     thumb,
     el('div', { class: 'caption' },
       el('h4', { text: label }),

--- a/public/js/gallery.js
+++ b/public/js/gallery.js
@@ -29,7 +29,10 @@ function item(obs) {
     : '';
   const label = obs.title || [id, obs.object_name].filter(Boolean).join(' · ') || `Observation #${obs.id}`;
   const meta = [obs.telescope, typeLabel(obs.object_type)].filter(Boolean).join(' · ');
-  const href = obs.object_id ? `/object.html?id=${obs.object_id}` : '#';
+  // Drill straight to the per-observation detail page; falls back to the
+  // object detail when somehow we don't have an observation id.
+  const href = obs.id ? `/observation.html?id=${obs.id}`
+    : (obs.object_id ? `/object.html?id=${obs.object_id}` : '#');
 
   return el('a', { class: 'gallery-item', href },
     thumb,

--- a/public/js/object.js
+++ b/public/js/object.js
@@ -185,7 +185,14 @@ async function render() {
       if (conditionBits.length) {
         captionChildren.push(el('small', { class: 'dim', text: conditionBits.join(' · ') }));
       }
-      grid.appendChild(el('div', { class: 'gallery-item' + (isFeatured ? ' is-featured' : '') },
+      // Wrap the tile in a link so the public viewer can drill into the
+      // full per-observation detail page (location map, moon phase,
+      // notes, prev/next within the same target).
+      grid.appendChild(el('a', {
+          class: 'gallery-item' + (isFeatured ? ' is-featured' : ''),
+          href: `/observation.html?id=${encodeURIComponent(o.id)}`,
+          style: 'text-decoration:none; color:inherit;',
+        },
         thumb,
         el('div', { class: 'caption' }, ...captionChildren),
       ));

--- a/public/js/observation.js
+++ b/public/js/observation.js
@@ -1,0 +1,257 @@
+import { fetchJson, el, formatRA, formatDec, typeLabel, qs } from './common.js';
+
+const root = document.getElementById('root');
+const id = qs('id');
+
+function meta(label, value) {
+  return [
+    el('dt', { class: 'k', text: label }),
+    el('dd', { class: 'v' }, value instanceof Node
+      ? value
+      : document.createTextNode(value == null || value === '' ? '—' : String(value))),
+  ];
+}
+
+// SVG moon — phase 0 = new, 0.5 = full, 1 = back to new. We render an
+// illuminated disc plus a shadow ellipse whose width matches the
+// terminator. Good enough for a small page chip; not for selenography.
+function moonSvg(phase) {
+  if (phase == null || Number.isNaN(Number(phase))) return null;
+  const p = Number(phase);
+  // Illuminated fraction 0..1; cosine of phase angle gives the lit width.
+  const lit = (1 - Math.cos(2 * Math.PI * p)) / 2;
+  // Direction of illumination: waxing (0..0.5) lit on the right; waning on left.
+  const waxing = p < 0.5;
+  const r = 24, cx = 28, cy = 28;
+  // Shadow is an ellipse: rx scales from r (new) -> 0 (full) -> r (new again).
+  const rx = Math.abs(1 - 2 * lit) * r;
+  // Place shadow centre on the lit-or-unlit side based on direction.
+  const shadowOffset = waxing ? -1 : 1;        // shadow on the unlit side
+  const cxShadow = cx + (lit < 0.5 ? 0 : shadowOffset * rx);
+  // For a waxing gibbous (lit > 0.5), the shadow curves inward from the
+  // unlit limb; we draw the lit disc and overlay an ellipse to carve it.
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 56 56');
+  svg.setAttribute('class', 'moon-svg');
+  svg.setAttribute('aria-hidden', 'true');
+  // Background disc (unlit)
+  const back = document.createElementNS(svg.namespaceURI, 'circle');
+  back.setAttribute('cx', cx); back.setAttribute('cy', cy); back.setAttribute('r', r);
+  back.setAttribute('fill', '#222');
+  back.setAttribute('stroke', '#888'); back.setAttribute('stroke-width', '1');
+  svg.appendChild(back);
+  // Lit half (always the half facing the sun): use a clip path to draw
+  // only one semicircle, then carve the terminator with an ellipse.
+  const clipId = `moon-clip-${Math.random().toString(36).slice(2)}`;
+  const defs = document.createElementNS(svg.namespaceURI, 'defs');
+  const clip = document.createElementNS(svg.namespaceURI, 'clipPath');
+  clip.setAttribute('id', clipId);
+  const halfRect = document.createElementNS(svg.namespaceURI, 'rect');
+  halfRect.setAttribute('y', cy - r);
+  halfRect.setAttribute('height', r * 2);
+  if (waxing) {
+    halfRect.setAttribute('x', cx); halfRect.setAttribute('width', r);     // right half lit
+  } else {
+    halfRect.setAttribute('x', cx - r); halfRect.setAttribute('width', r); // left half lit
+  }
+  clip.appendChild(halfRect);
+  defs.appendChild(clip);
+  svg.appendChild(defs);
+  const lit_disc = document.createElementNS(svg.namespaceURI, 'circle');
+  lit_disc.setAttribute('cx', cx); lit_disc.setAttribute('cy', cy); lit_disc.setAttribute('r', r);
+  lit_disc.setAttribute('fill', '#f1e9c2');
+  lit_disc.setAttribute('clip-path', `url(#${clipId})`);
+  svg.appendChild(lit_disc);
+  // Terminator ellipse: shifts the lit/unlit boundary along the x axis.
+  // Lit fraction < 0.5 → terminator lies inside the lit half (carving lit
+  // away). Lit fraction > 0.5 → terminator lies inside the unlit half
+  // (extending lit into it). We draw lit-coloured for the >0.5 case and
+  // unlit-coloured for the <0.5 case.
+  const term = document.createElementNS(svg.namespaceURI, 'ellipse');
+  term.setAttribute('cx', cx); term.setAttribute('cy', cy);
+  term.setAttribute('rx', rx); term.setAttribute('ry', r);
+  term.setAttribute('fill', lit < 0.5 ? '#222' : '#f1e9c2');
+  svg.appendChild(term);
+  return svg;
+}
+
+function locationCard(o) {
+  const wrap = el('div', { class: 'meta-list', style: 'margin-top:0.5rem;' });
+  if (!o.latitude || !o.longitude) {
+    wrap.appendChild(el('p', { class: 'dim', text: o.location || 'No GPS recorded.' }));
+    return wrap;
+  }
+  if (o.location) wrap.appendChild(el('p', { class: 'dim', style: 'margin:0;', text: o.location }));
+  wrap.appendChild(el('p', { class: 'dim', style: 'margin:0;',
+    text: `${o.latitude.toFixed(4)}, ${o.longitude.toFixed(4)}` }));
+  const mapDiv = el('div', { id: 'obs-map' });
+  wrap.appendChild(mapDiv);
+  // Defer map init until the element is in the DOM.
+  setTimeout(() => {
+    if (typeof L === 'undefined') return;
+    const map = L.map('obs-map', { zoomControl: true }).setView([o.latitude, o.longitude], 8);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap',
+      maxZoom: 18,
+    }).addTo(map);
+    L.marker([o.latitude, o.longitude]).addTo(map);
+  }, 0);
+  return wrap;
+}
+
+function fmtCondition(o) {
+  const bits = [];
+  if (o.bortle != null) bits.push(`Bortle ${o.bortle}`);
+  if (o.sqm != null) bits.push(`SQM ${Number(o.sqm).toFixed(2)}`);
+  if (o.seeing != null) bits.push(`seeing ${o.seeing}/5`);
+  if (o.transparency != null) bits.push(`transparency ${o.transparency}/5`);
+  return bits.length ? bits.join(' · ') : '—';
+}
+
+function fmtCapture(o) {
+  const bits = [];
+  if (o.stack_count != null && o.exposure_seconds != null) {
+    bits.push(`${o.stack_count}×${o.exposure_seconds}s`);
+    const totalMin = (o.stack_count * o.exposure_seconds) / 60;
+    bits.push(`${totalMin.toFixed(1)} min total`);
+  } else if (o.exposure_seconds != null) {
+    bits.push(`${o.exposure_seconds}s`);
+  }
+  if (o.gain != null) bits.push(`gain ${o.gain}`);
+  if (o.iso != null) bits.push(`ISO ${o.iso}`);
+  if (o.filter_name) bits.push(`filter ${o.filter_name}`);
+  return bits.length ? bits.join(' · ') : '—';
+}
+
+async function render() {
+  if (!id) {
+    root.innerHTML = '<p class="muted">Missing observation id.</p>';
+    return;
+  }
+  let data;
+  try {
+    data = await fetchJson(`/api/observations/${encodeURIComponent(id)}`);
+  } catch {
+    root.innerHTML = '<p class="muted">Observation not found.</p>';
+    return;
+  }
+  const o = data.observation;
+  const targetLabel = (o.catalog && o.catalog_number) ? `${o.catalog}${o.catalog_number}` : (o.title || `#${o.id}`);
+  document.title = `DeepSkyLog — ${targetLabel}`;
+
+  root.innerHTML = '';
+
+  // Breadcrumb back to the object detail (when list-backed) or gallery.
+  const back = o.list_object_id
+    ? el('a', { href: `/object.html?id=${encodeURIComponent(o.list_object_id)}`,
+                text: `← ${targetLabel} (${data.sibling_count} attempt${data.sibling_count === 1 ? '' : 's'})` })
+    : el('a', { href: '/gallery.html', text: '← Gallery' });
+  root.appendChild(el('p', { class: 'dim' }, back));
+
+  // Title + subtitle
+  const title = o.list_object_name || o.object_name || o.title || targetLabel;
+  root.appendChild(el('h1', { class: 'page-title', text: title }));
+  const subBits = [
+    typeLabel(o.list_object_type || o.object_type),
+    o.list_object_constellation,
+    o.observed_at ? new Date(o.observed_at).toLocaleString() : (o.created_at ? new Date(o.created_at).toLocaleDateString() : null),
+  ].filter(Boolean);
+  root.appendChild(el('p', { class: 'page-subtitle', text: subBits.join(' · ') }));
+
+  // Prev/next nav
+  const navRow = el('div', { class: 'obs-nav' });
+  const prev = data.prev_id
+    ? el('a', { class: 'button-link ghost-link', href: `/observation.html?id=${data.prev_id}`, text: '← Previous' })
+    : el('span', { class: 'button-link ghost-link', style: 'opacity:0.5; pointer-events:none;', text: '← Previous' });
+  const next = data.next_id
+    ? el('a', { class: 'button-link ghost-link', href: `/observation.html?id=${data.next_id}`, text: 'Next →' })
+    : el('span', { class: 'button-link ghost-link', style: 'opacity:0.5; pointer-events:none;', text: 'Next →' });
+  navRow.appendChild(prev);
+  navRow.appendChild(el('span', { class: 'pos dim',
+    text: `Attempt ${data.sibling_index + 1} of ${data.sibling_count}` }));
+  navRow.appendChild(next);
+  root.appendChild(navRow);
+
+  // Hero: image left, sidebar metadata right
+  const heroLeft = el('div', { class: 'obs-photo' });
+  if (o.image_path) {
+    heroLeft.appendChild(el('img', { src: `/uploads/${o.image_path}`, alt: title, loading: 'lazy' }));
+  } else {
+    heroLeft.appendChild(el('div', { class: 'empty', text: 'No image uploaded.' }));
+  }
+
+  // Object metadata block (catalog RA/Dec when list-backed; otherwise the
+  // per-observation RA/Dec we store for free-form objects like comets).
+  const ra = o.list_object_ra_hours ?? o.ra_hours;
+  const dec = o.list_object_dec_degrees ?? o.dec_degrees;
+  const objectMeta = el('dl', { class: 'meta-list' },
+    ...meta('Catalog', (o.catalog && o.catalog_number) ? `${o.catalog}${o.catalog_number}` : '—'),
+    ...meta('Type', typeLabel(o.list_object_type || o.object_type)),
+    ...meta('Constellation', o.list_object_constellation || '—'),
+    ...meta('Right ascension', formatRA(ra)),
+    ...meta('Declination', formatDec(dec)),
+    ...meta('Magnitude', (o.list_object_magnitude != null) ? Number(o.list_object_magnitude).toFixed(1) : '—'),
+  );
+
+  // Capture details
+  const captureMeta = el('dl', { class: 'meta-list' },
+    ...meta('Telescope', o.telescope),
+    ...meta('Camera', o.camera),
+    ...meta('Capture', fmtCapture(o)),
+    ...meta('Focal length', o.focal_length_mm != null ? `${o.focal_length_mm} mm` : '—'),
+    ...meta('Aperture', o.aperture != null ? `f/${Number(o.aperture).toFixed(1)}` : '—'),
+    ...meta('Conditions', fmtCondition(o)),
+    ...meta('Rating', o.rating ? '★'.repeat(o.rating) + '☆'.repeat(5 - o.rating) : '—'),
+  );
+
+  // Moon card
+  const moonCard = el('div', { class: 'moon-card' });
+  const moonSvgEl = moonSvg(o.moon_phase);
+  if (moonSvgEl) moonCard.appendChild(moonSvgEl);
+  moonCard.appendChild(el('div', {},
+    el('div', { style: 'font-weight:600;', text: o.moon_phase_name || 'Moon' }),
+    el('div', { class: 'dim', style: 'font-size:0.85em;',
+      text: o.moon_phase != null
+        ? `${(((1 - Math.cos(2 * Math.PI * Number(o.moon_phase))) / 2) * 100).toFixed(0)}% illuminated`
+        : 'Phase not recorded.' }),
+  ));
+
+  // Location
+  const locCard = locationCard(o);
+
+  const sidebar = el('div', {},
+    el('h3', { style: 'margin-top:0;', text: 'Object' }),
+    objectMeta,
+    el('h3', { text: 'Capture' }),
+    captureMeta,
+    el('h3', { text: 'Moon' }),
+    moonCard,
+    el('h3', { text: 'Location' }),
+    locCard,
+  );
+
+  root.appendChild(el('section', { class: 'obs-hero' }, heroLeft, sidebar));
+
+  // Notes
+  if (o.description) {
+    root.appendChild(el('section', { class: 'section' },
+      el('h2', { text: 'Notes' }),
+      el('p', { text: o.description, style: 'white-space:pre-wrap;' }),
+    ));
+  }
+
+  // Bottom prev/next mirror
+  root.appendChild(navRow.cloneNode(true));
+}
+
+// Arrow-key shortcuts for prev/next when the user isn't typing.
+document.addEventListener('keydown', (e) => {
+  if (e.target && /^(input|textarea|select)$/i.test(e.target.tagName)) return;
+  if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+  const link = document.querySelector(
+    e.key === 'ArrowLeft' ? '.obs-nav a[href*="/observation.html"]:first-of-type' : '.obs-nav a[href*="/observation.html"]:last-of-type',
+  );
+  if (link) link.click();
+});
+
+render();

--- a/public/observation.html
+++ b/public/observation.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DeepSkyLog &mdash; Observation</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet"
+          href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossorigin="" />
+    <style>
+      .obs-hero { display:grid; grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr); gap: 1.25rem; }
+      @media (max-width: 800px) { .obs-hero { grid-template-columns: 1fr; } }
+      .obs-photo img { width:100%; height:auto; border-radius: 8px; display:block; }
+      .obs-photo .empty { padding: 3rem 1rem; text-align: center; border: 1px dashed var(--border, #444); border-radius: 8px; }
+      .obs-nav { display:flex; gap:0.5rem; align-items:center; justify-content:space-between; margin: 0.5rem 0 1rem; }
+      .obs-nav .pos { font-size:0.85em; }
+      .moon-card { display:flex; gap:0.75rem; align-items:center; padding: 0.5rem 0.75rem; border:1px solid var(--border, #333); border-radius: 6px; }
+      .moon-svg { width: 56px; height: 56px; flex: 0 0 auto; }
+      #obs-map { height: 240px; border-radius: 6px; margin-top: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span class="brand-name">DeepSkyLog</span>
+      </div>
+      <nav class="site-nav">
+        <a href="/" data-nav="home">Dashboard</a>
+        <a href="/tonight.html" data-nav="tonight">Tonight</a>
+        <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/gallery.html" data-nav="gallery">Gallery</a>
+        <a href="/map.html" data-nav="map">Map</a>
+      </nav>
+    </header>
+    <main id="root">
+      <p class="muted">Loading observation&hellip;</p>
+    </main>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+            crossorigin=""></script>
+    <script type="module" src="/js/observation.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
+  </body>
+</html>

--- a/server.js
+++ b/server.js
@@ -685,6 +685,62 @@ app.get('/api/observations.csv', (_req, res) => {
   res.send(lines.join('\n'));
 });
 
+// Public per-observation detail endpoint. Joins to the catalog row when the
+// observation is list-backed and finds the previous / next siblings under
+// the same target (matched on the same catalog+number tokens used by the
+// cross-list ticking) so the public page can offer prev/next nav.
+app.get('/api/observations/:id', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+  const row = db
+    .prepare(
+      `SELECT o.*,
+              lo.id            AS list_object_id,
+              lo.name          AS list_object_name,
+              lo.object_type   AS list_object_type,
+              lo.constellation AS list_object_constellation,
+              lo.ra_hours      AS list_object_ra_hours,
+              lo.dec_degrees   AS list_object_dec_degrees,
+              lo.magnitude     AS list_object_magnitude,
+              l.slug           AS list_slug,
+              l.name           AS list_name
+         FROM observations o
+         LEFT JOIN list_objects lo ON lo.id = o.object_id
+         LEFT JOIN lists l ON l.id = lo.list_id
+         WHERE o.id = ?`,
+    )
+    .get(id);
+  if (!row) return res.status(404).json({ error: 'Observation not found' });
+
+  // Siblings: every observation that shares the same catalog+number
+  // (case- and whitespace-insensitive). Same predicate as the object
+  // detail page uses, so results agree.
+  const token = `${row.catalog || ''}${row.catalog_number || ''}`.toUpperCase().replace(/\s+/g, '');
+  const siblings = token
+    ? db
+        .prepare(
+          `SELECT id, observed_at, created_at, thumbnail_path
+             FROM observations
+             WHERE UPPER(REPLACE(catalog || catalog_number, ' ', '')) = ?
+             ORDER BY COALESCE(observed_at, created_at) ASC, id ASC`,
+        )
+        .all(token)
+    : [{ id: row.id, observed_at: row.observed_at, created_at: row.created_at, thumbnail_path: row.thumbnail_path }];
+
+  const idx = siblings.findIndex((s) => s.id === row.id);
+  const prev = idx > 0 ? siblings[idx - 1] : null;
+  const next = idx >= 0 && idx < siblings.length - 1 ? siblings[idx + 1] : null;
+
+  res.json({
+    observation: row,
+    siblings,
+    prev_id: prev?.id ?? null,
+    next_id: next?.id ?? null,
+    sibling_index: idx >= 0 ? idx : 0,
+    sibling_count: siblings.length,
+  });
+});
+
 // iCalendar feed of dark-sky weekends (Fri–Sun) over the next 12 months,
 // anchored on each new moon. Subscribe in any calendar app for a one-glance
 // view of the best imaging windows.

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -528,6 +528,49 @@ test('smoke', async (t) => {
     });
   });
 
+  await t.test('public per-observation detail with prev/next siblings', async () => {
+    const auth = { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') };
+    // Stage two M81 observations so we can exercise sibling navigation.
+    const messier = await fetchJsonAuthed('/api/lists/messier');
+    const m81 = messier.objects.find((o) => o.catalog_number === '81');
+    assert.ok(m81);
+    const ids = [];
+    for (const day of ['2026-04-10T22:00', '2026-04-12T22:00']) {
+      const jpeg = await buildSyntheticJpeg();
+      const fd = new FormData();
+      fd.set('image', new Blob([jpeg], { type: 'image/jpeg' }), 'm81.jpg');
+      const stage = await fetch(`${baseUrl}/api/admin/stage`, { method: 'POST', headers: auth, body: fd })
+        .then((r) => r.json());
+      const obs = await fetch(`${baseUrl}/api/admin/observations`, {
+        method: 'POST', headers: { ...auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          stage_id: stage.stage_id,
+          object_id: m81.id, catalog: 'M', catalog_number: '81',
+          object_name: "Bode's Galaxy", telescope: 'Seestar S30 Pro',
+          observed_at: day,
+        }),
+      }).then((r) => r.json());
+      ids.push(obs.id);
+    }
+    // First (earlier) observation: no prev, has next.
+    const first = await (await fetch(`${baseUrl}/api/observations/${ids[0]}`)).json();
+    assert.equal(first.observation.id, ids[0]);
+    assert.equal(first.observation.list_object_id, m81.id);
+    assert.equal(first.observation.list_object_name, "Bode's Galaxy");
+    assert.equal(first.prev_id, null);
+    assert.equal(first.next_id, ids[1]);
+    assert.equal(first.sibling_count, 2);
+    assert.equal(first.sibling_index, 0);
+    // Last observation: has prev, no next.
+    const second = await (await fetch(`${baseUrl}/api/observations/${ids[1]}`)).json();
+    assert.equal(second.prev_id, ids[0]);
+    assert.equal(second.next_id, null);
+    assert.equal(second.sibling_index, 1);
+    // Unknown id -> 404.
+    const miss = await fetch(`${baseUrl}/api/observations/99999`);
+    assert.equal(miss.status, 404);
+  });
+
   await t.test('admin stats includes lifetime panel with streak data', async () => {
     const data = await fetchJsonAuthed('/api/admin/stats');
     assert.ok(data.lifetime, 'lifetime block present');


### PR DESCRIPTION
## Summary
A new public-side per-observation detail page reachable from gallery and target tiles.

- New `/observation.html?id=N`:
  - Hero photo + object metadata (catalog, RA/Dec, type, constellation; per-observation RA/Dec for free-form/comet rows)
  - Capture details (telescope, exposure × stack count, gain, filter, ISO, focal length, aperture, rating)
  - Sky conditions (Bortle, SQM, seeing, transparency)
  - **Moon phase visual** rendered as inline SVG from the stored phase fraction (waxing/waning, terminator ellipse, % illumination label, phase name)
  - **Location panel**: lat/lon + a small Leaflet map marker (only when GPS is recorded)
  - **Prev / next** links between siblings under the same target — also bound to ← / → arrow keys
- New endpoint `GET /api/observations/:id` joins to `list_objects` when list-backed and computes `prev_id` / `next_id` from the same catalog+number tokens the cross-list ticking uses. `sibling_count` and `sibling_index` round it out.
- `/gallery.html` and `/object.html` tiles now route to the detail page instead of the parent target. Breadcrumb leads back so navigation stays obvious.

## Design choices (call out anything to redirect)
- **Moon image:** inline SVG (no external assets, no extra requests). Crescent + gibbous look right; precision is decorative, not selenographic.
- **Map provider:** OpenStreetMap via Leaflet (already used on `/map.html`). One marker, no overlays.
- **Sibling ordering:** chronological by `observed_at` (falling back to `created_at`), ascending. Prev = older, Next = newer.
- **Free-form / comet rows:** prev/next still works using the typed catalog+number; if those are blank the page just shows the single observation with no siblings.

## Test plan
- [x] `npm test` (smoke) green: 28/28 (added one new sub-test)
- [ ] Manual: click an image on `/gallery.html` → detail page loads with map + moon
- [ ] Manual: target with multiple attempts → prev/next walks them; ← / → keys do the same
- [ ] Manual: target with no GPS → location panel shows the location string only, no map


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_