### PR TITLE
Fix NGC lookup: zero-padded names + trigger from EXIF guesses

### DIFF
--- a/admin/upload.js
+++ b/admin/upload.js
@@ -386,7 +386,11 @@ function onStaged(res) {
   if (targetGuess && !objectInput.value) {
     objectInput.value = targetGuess;
     searchObjects(targetGuess);
-    setTimeout(resolveObjectFromInput, 150);
+    // Setting .value programmatically doesn't fire 'input', so we have to
+    // run the resolver and the NGC fallback explicitly. Resolver first so
+    // a seeded match wins; fallback fills catalog/RA/Dec for everything
+    // else (e.g. an EXIF target of "IC 410" that isn't in any seed).
+    setTimeout(() => { resolveObjectFromInput(); tryNgcFallback(); }, 150);
   }
 
   // Total integration time from the watermark ("52min") goes into the

--- a/lib/ngc.js
+++ b/lib/ngc.js
@@ -31,7 +31,11 @@ function load() {
 }
 
 function normalise(s) {
-  return String(s || '').toUpperCase().replace(/\s+/g, '').trim();
+  const upper = String(s || '').toUpperCase().replace(/\s+/g, '').trim();
+  // OpenNGC stores names zero-padded ("IC0410", "NGC0001") but users type
+  // the unpadded form ("IC410", "NGC1"). Strip leading zeros after the
+  // alpha prefix so both representations collide on the same key.
+  return upper.replace(/^([A-Z]+)0+(\d)/, '$1$2');
 }
 
 // "05:35:17.30" -> 5.587..  (decimal hours)

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -725,6 +725,19 @@ test('smoke', async (t) => {
       headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },
     });
     assert.equal(miss.status, 404);
+
+    // Leading zeros in OpenNGC names ("IC0410") must collide with the
+    // unpadded form users type ("IC410"). Regression for the bug where
+    // typing IC410 silently failed to auto-fill catalog/RA/Dec.
+    const auth = { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') };
+    const ic410 = await fetch(`${baseUrl}/api/admin/objects/lookup?q=IC410`, { headers: auth });
+    assert.equal(ic410.status, 200, 'IC410 should resolve via the unpadded form');
+    const ic = await ic410.json();
+    assert.equal(ic.catalog, 'IC');
+    assert.equal(ic.catalog_number, '410');
+    // "ic 410" with whitespace and lowercase still works.
+    const sloppy = await fetch(`${baseUrl}/api/admin/objects/lookup?q=ic%20410`, { headers: auth });
+    assert.equal(sloppy.status, 200);
   });
 
   await t.test('batch staging: many parallel stages succeed independently', async () => {


### PR DESCRIPTION
## Summary
Fixes the screenshot bug: typing `IC410` in the upload form leaves catalog + catalog_number empty and shows "Not in a seeded list" even though IC 410 is in the bundled OpenNGC dataset.

Two issues, one PR:

1. **Normaliser missed zero-padded names.** OpenNGC stores `IC0410` / `NGC0001`; users type `IC410` / `NGC1`. The cache key for one form never collided with the other. `normalise()` now strips leading zeros after the alpha prefix so both forms map to the same key. `M42`, `Orion Nebula`, `NGC1976` (no leading zeros) keep working unchanged.

2. **EXIF/filename guesses didn't trigger the fallback.** `onStaged()` set `objectInput.value` programmatically, which doesn't fire `input` events, so the typing-pause timer that runs the NGC lookup never armed. Now `onStaged` calls `tryNgcFallback()` directly after the auto-fill — so an EXIF target of `IC 410` populates catalog/RA/Dec/type the same as if you'd typed it.

## Test plan
- [x] `npm test` (smoke) green: 29/29 — added regression covering `IC410` + `ic 410` sloppy form.
- [ ] Manual: type `IC410` in the upload object field — catalog `IC`, # `410`, type/constellation populate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_