### PR TITLE
Batch upload: object/catalog/RA-Dec are per-image, not carried over

### DIFF
--- a/admin/upload.js
+++ b/admin/upload.js
@@ -314,26 +314,24 @@ function renderQueue() {
 function setActiveStage(idx) {
   const item = stageQueue[idx];
   if (!item) return;
-  // Reset only per-image fields; preserve user-typed shared fields like
-  // telescope, target, location, rating, notes for the next item in batch.
+  // resetPerImageFields() clears every per-frame field including the
+  // object block; onStaged() then re-fills from the new item's EXIF /
+  // filename guess. Shared-across-batch fields (telescope, location,
+  // rating, conditions, notes) are intentionally preserved.
   resetPerImageFields();
   onStaged(item);
   renderQueue();
-  // Re-resolve the carried-over object value against the new item: this
-  // re-runs both the seeded match and the NGC fallback so e.g. an IC410
-  // typed for the previous chip still auto-fills catalog when you switch
-  // back to it from a chip whose EXIF named M42.
-  if (objectInput.value.trim()) {
-    searchObjects(objectInput.value.trim());
-    setTimeout(() => { resolveObjectFromInput(); tryNgcFallback(); }, 150);
-  }
 }
 
 function resetPerImageFields() {
   stageIdField.value = '';
   exifSummary.innerHTML = '';
   previewImg.removeAttribute('src');
-  // Per-image: date, GPS, exposure/gain/stack/filter, sidecar JSON.
+  // Per-image: date, GPS, exposure/gain/stack/filter, sidecar JSON, and
+  // the object/catalog/RA-Dec block. Each Seestar filename embeds its own
+  // target, so it's wrong to carry the first chip's value (e.g. C4) over
+  // a queue of mixed targets — every chip's onStaged() refills these from
+  // its own EXIF/filename guess.
   dateInput.value = '';
   latitudeInput.value = '';
   longitudeInput.value = '';
@@ -345,6 +343,14 @@ function resetPerImageFields() {
   filterInput.value = '';
   seestarJsonField.value = '';
   moonDisplay.value = '';
+  objectInput.value = '';
+  objectIdField.value = '';
+  catalogInput.value = '';
+  catalogNumberInput.value = '';
+  objectTypeInput.value = '';
+  raHoursInput.value = '';
+  decDegreesInput.value = '';
+  objectHint.textContent = '';
 }
 
 function onStaged(res) {


### PR DESCRIPTION
## Summary
Fixes the screenshot bug: bulk upload pasted the first chip's object (e.g. `C4`) into every subsequent chip, even when those chips' filenames named different targets (`M33`, `IC410`, etc.).

**Root cause.** The old design treated object/target as a "shared" batch-session field — `onStaged()` only auto-filled the object input when it was empty, assuming "telescope/target/location carry over". That works for ten subs of M42, but Seestar batches are usually mixed targets and every filename embeds its own target.

**Fix.** Move `object`, `objectIdField`, `catalog`, `catalog_number`, `object_type`, `ra_hours`, `dec_degrees`, and the object hint into the per-image reset block. Each chip reload pulls those values fresh from the active item's EXIF/filename guess. Telescope, location, rating, conditions, notes still carry over — those genuinely don't change between subs.

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual: drop a mixed batch (C4, M31, IC410, M33) — clicking through chips should show each item's own target, not the first one's.
- [ ] Manual: drop ten subs of the same target — telescope/location/rating still carry; target naturally repeats since every filename has it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_