### PR TITLE
Upload: relax step on lat/lon/RA/Dec so EXIF precision passes validation

### DIFF
--- a/admin/upload.html
+++ b/admin/upload.html
@@ -93,11 +93,11 @@
             <div class="row" id="ra-dec-row">
               <label class="field">
                 <span>RA (hours)</span>
-                <input id="ra-hours-input" name="ra_hours" type="number" step="0.0001" min="0" max="24" placeholder="e.g. 5.5878" />
+                <input id="ra-hours-input" name="ra_hours" type="number" step="any" min="0" max="24" placeholder="e.g. 5.5878" />
               </label>
               <label class="field">
                 <span>Dec (°)</span>
-                <input id="dec-degrees-input" name="dec_degrees" type="number" step="0.0001" min="-90" max="90" placeholder="e.g. -5.391" />
+                <input id="dec-degrees-input" name="dec_degrees" type="number" step="any" min="-90" max="90" placeholder="e.g. -5.391" />
               </label>
               <small class="dim" style="flex-basis:100%;">Per-observation sky position. Useful for comets and other moving targets.</small>
             </div>
@@ -121,11 +121,11 @@
             <div class="row">
               <label class="field">
                 <span>Latitude</span>
-                <input id="latitude-input" name="latitude" type="number" step="0.0001" min="-90" max="90" placeholder="51.4769" />
+                <input id="latitude-input" name="latitude" type="number" step="any" min="-90" max="90" placeholder="51.4769" />
               </label>
               <label class="field">
                 <span>Longitude</span>
-                <input id="longitude-input" name="longitude" type="number" step="0.0001" min="-180" max="180" placeholder="-0.0005" />
+                <input id="longitude-input" name="longitude" type="number" step="any" min="-180" max="180" placeholder="-0.0005" />
               </label>
               <label class="field" style="flex:0 0 auto; align-self:flex-end;">
                 <span>&nbsp;</span>


### PR DESCRIPTION
## Summary
Fixes the screenshot validation popup ("The two nearest valid values are 42.0833 and 42.0834").

The latitude input was declared `step="0.0001"`, but EXIF prefill calls `.toFixed(6)`, producing `42.083333` — not a multiple of 0.0001, which the browser then refuses on submit. Same trap on `ra_hours` and `dec_degrees`, both populated at higher precision by EXIF, FITS solves, and the NGC fallback.

Switched all four to `step="any"`; the min/max bounds (±90 / ±180 / 0–24) still constrain. SQM stays at `step="0.01"` since it's only ever set to two decimal places.

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual: drop a JPG with EXIF GPS → save observation → no validation popup


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_