### PR TITLE
Upload: await searchObjects so seeded match wins (no more 150ms race)

### DIFF
--- a/admin/upload.js
+++ b/admin/upload.js
@@ -353,7 +353,7 @@ function resetPerImageFields() {
   objectHint.textContent = '';
 }
 
-function onStaged(res) {
+async function onStaged(res) {
   currentStage = res;
   stageIdField.value = res.stage_id;
   previewImg.src = res.preview_url;
@@ -399,12 +399,14 @@ function onStaged(res) {
   const targetGuess = res.guesses?.target?.raw || res.exif?.object_name;
   if (targetGuess && !objectInput.value) {
     objectInput.value = targetGuess;
-    searchObjects(targetGuess);
-    // Setting .value programmatically doesn't fire 'input', so we have to
-    // run the resolver and the NGC fallback explicitly. Resolver first so
-    // a seeded match wins; fallback fills catalog/RA/Dec for everything
-    // else (e.g. an EXIF target of "IC 410" that isn't in any seed).
-    setTimeout(() => { resolveObjectFromInput(); tryNgcFallback(); }, 150);
+    // Wait for the seeded search so the cache is populated before we
+    // resolve. The previous setTimeout(150) raced the fetch on slow
+    // networks — by the time it fired, objectCache was still empty,
+    // resolveObjectFromInput cleared catalog/number, and the NGC
+    // fallback then 404'd for Messier IDs that aren't in OpenNGC.
+    await searchObjects(targetGuess);
+    resolveObjectFromInput();
+    if (!objectIdField.value) await tryNgcFallback();
   }
 
   // Total integration time from the watermark ("52min") goes into the


### PR DESCRIPTION
## Summary

Why this keeps regressing: every fix to the seeded-resolve path left in a `setTimeout(150)` racing the seeded-list fetch. On a slow network the resolver fired with an empty `objectCache`, cleared catalog and number (correct behaviour for "no match"), and then the NGC fallback 404'd because Messier IDs aren't in the OpenNGC bundle. Net effect: typing `M33` left CATALOG ID blank — the screenshot bug.

**Fix.** Make `onStaged` async, `await searchObjects(targetGuess)`, then run `resolveObjectFromInput()` synchronously after. No more timing window. The NGC fallback only runs when the seeded resolver didn't find a match (avoiding a wasted lookup for every Messier ID).

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual: drop a batch with M33, M42, NGC7000, IC410 — clicking each chip should populate catalog/number/type


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_