### PR TITLE
Planner: wrap LIST column so the table doesn't overflow on long names

### DIFF
--- a/public/js/planner.js
+++ b/public/js/planner.js
@@ -133,7 +133,7 @@ async function load() {
       el('td', { text: fmtTime(t.max_altitude_at) }),
       el('td', { text: fmtMinutes(t.minutes_above_min) }),
       el('td', { text: t.moon_separation_deg != null ? `${t.moon_separation_deg.toFixed(0)}°` : '—' }),
-      el('td', { class: 'dim', text: t.list_name }),
+      el('td', { class: 'dim list-cell', text: t.list_name }),
     ));
   }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -260,6 +260,17 @@ th, td {
   white-space: nowrap;
 }
 
+/* Long list names ("Astronomical League — Globular Clusters",
+   "Planetary Nebulae for Smart Scopes") were forcing the planner table
+   wider than its container and sliding off the right edge. Allow that
+   one cell to wrap and cap its width so the rest of the columns stay
+   on one line. */
+td.list-cell {
+  white-space: normal;
+  max-width: 16rem;
+  line-height: 1.2;
+}
+
 thead th {
   position: sticky;
   top: 0;


### PR DESCRIPTION
## Summary
Fixes the planner table where the LIST column was sliding off the right edge — values like `Caldwel`, `Local G`, `Sharple` truncated visibly.

The cause: long seeded-list names ("Astronomical League — Globular Clusters", "Planetary Nebulae for Smart Scopes") combined with the global `white-space: nowrap` on `td` cells pushed the table past its 1200 px wrapper. The wrapper's `overflow:auto` would horizontally scroll, but at typical desktop widths the right edge was already cut off.

Tagged the LIST cell with a `.list-cell` class and overrode it to wrap (`white-space: normal`, `max-width: 16rem`). Other columns keep nowrap.

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual: load `/planner.html` — long list names wrap inside the LIST column; no horizontal overflow on a 1200 px viewport


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_