### PR TITLE
Upload: sub-exposure auto-fill from filename + handle Seestar mosaic_ prefix

### DIFF
--- a/admin/upload.js
+++ b/admin/upload.js
@@ -407,6 +407,13 @@ function onStaged(res) {
     setTimeout(() => { resolveObjectFromInput(); tryNgcFallback(); }, 150);
   }
 
+  // Sub-exposure (per frame): prefer the EXIF / filename value the server
+  // already extracted; fall back to the OCR'd total integration so legacy
+  // behaviour is preserved if no per-frame value is known. The user can
+  // override either way.
+  if (res.exif?.exposure_seconds != null && !exposureInput.value) {
+    exposureInput.value = res.exif.exposure_seconds;
+  }
   // Total integration time from the watermark ("52min") goes into the
   // exposure input only if the user hasn't filled it from EXIF or sidecar.
   const totalExposure = res.guesses?.total_exposure_seconds;

--- a/lib/seestar_meta.js
+++ b/lib/seestar_meta.js
@@ -88,8 +88,9 @@ function parsePhotographer(text) {
 // Seestar export filenames are highly structured, e.g.
 //   Stacked_206_C 4_10.0s_IRCUT_20241027-213334.jpg
 //   Light_206_M 31_30.0s_LP_20240901-021500.fits
+//   Stacked_570_mosaic_M 31_10.0s_IRCUT_20250927-234646.jpg  (mosaic prefix)
 // Decoded:
-//   <kind>_<count>_<target>_<sub_exposure>s_<filter>_<YYYYMMDD>-<HHMMSS>
+//   <kind>_<count>_[mosaic_]<target>_<sub_exposure>s_<filter>_<YYYYMMDD>-<HHMMSS>
 // Older firmware sometimes drops the count or the filter; we accept those.
 function parseFilename(name) {
   if (!name) return null;
@@ -99,13 +100,18 @@ function parseFilename(name) {
   );
   if (!m) return null;
   const [, count, target, exp, filter, ymd, hms] = m;
+  // The Seestar app prepends 'mosaic_' for mosaic stacks. Strip it so the
+  // target reads as e.g. "M 31" (parseTarget'able) instead of "mosaic_M 31"
+  // — there's no \b boundary between '_' and 'M', so the catalog regex
+  // would otherwise never fire on a mosaic file.
+  const cleanedTarget = target.replace(/^mosaic_/i, '').trim();
   const captured_at =
     `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}T` +
     `${hms.slice(0, 2)}:${hms.slice(2, 4)}:${hms.slice(4, 6)}`;
   return {
     stack_count: count ? Number(count) : null,
-    target: parseTarget(target),
-    target_raw: target.trim(),
+    target: parseTarget(cleanedTarget),
+    target_raw: cleanedTarget,
     exposure_seconds: Number(exp),
     filter_name: filter || null,
     captured_at,


### PR DESCRIPTION
## Summary
Fixes the screenshot bug: filename was `Stacked_570_mosaic_M 31_10.0s_IRCUT_…`, the form filled stack count and filter from it, but Sub Exposure stayed blank.

Two problems on the same code path:

1. **Client never read `res.exif.exposure_seconds`.** The server was already extracting `10` from the filename into the staged response, but the upload module only consumed the sidecar JSON value and the OCR'd "total integration" string. Added an explicit prefill from `res.exif.exposure_seconds`, kept the OCR fallback for legacy behaviour.
2. **`mosaic_` prefix broke target parsing.** Mosaic exports drop a `mosaic_` token into the target slot. `parseTarget("mosaic_M 31")` returned null because `\b` doesn't fire between `_` and `M`. Strip the leading `mosaic_` in `parseFilename` before forwarding to `parseTarget`, so the catalog match works.

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [x] Manual reproducer in Node: parseFilename now returns `{stack_count:570, target:{catalog:"M",number:"31",raw:"M31"}, exposure_seconds:10, filter_name:"IRCUT", captured_at:"2025-09-27T23:46:46"}`.
- [ ] Manual: drop a Seestar mosaic JPG → Sub Exposure auto-fills with the filename value.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_