### PR TITLE
Planner: sort by altitude at the chosen time, add 'Alt now' column

### DIFF
--- a/public/js/planner.js
+++ b/public/js/planner.js
@@ -117,18 +117,22 @@ async function load() {
   status.textContent = `${data.targets.length} target${data.targets.length === 1 ? '' : 's'} reaching ≥${minAlt}°`;
 
   if (!data.targets.length) {
-    rows.appendChild(el('tr', {}, el('td', { colspan: '10' },
+    rows.appendChild(el('tr', {}, el('td', { colspan: '11' },
       el('div', { class: 'empty-state', text: 'Nothing clears the minimum altitude during this window.' }))));
     return;
   }
 
   for (const t of data.targets) {
-    rows.appendChild(el('tr', { class: t.observed ? 'observed' : '' },
+    // Dim targets that are below the horizon at the chosen moment so the
+    // user can see at a glance which ones are already up.
+    const below = t.altitude_at_start != null && t.altitude_at_start < 0;
+    rows.appendChild(el('tr', { class: [t.observed ? 'observed' : '', below ? 'dim' : ''].filter(Boolean).join(' ') },
       el('td', {}, el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
       el('td', { text: t.name || '—' }),
       el('td', { text: typeLabel(t.object_type) }),
       el('td', { text: t.constellation || '—' }),
       el('td', { text: t.magnitude != null ? Number(t.magnitude).toFixed(1) : '—' }),
+      el('td', { text: fmtDeg(t.altitude_at_start) }),
       el('td', { text: fmtDeg(t.max_altitude) }),
       el('td', { text: fmtTime(t.max_altitude_at) }),
       el('td', { text: fmtMinutes(t.minutes_above_min) }),

--- a/public/planner.html
+++ b/public/planner.html
@@ -69,6 +69,7 @@
               <th>Type</th>
               <th>Constellation</th>
               <th>Mag</th>
+              <th>Alt now</th>
               <th>Max alt</th>
               <th>At</th>
               <th>Above min for</th>

--- a/server.js
+++ b/server.js
@@ -500,6 +500,8 @@ app.get('/api/planner', (req, res) => {
     let firstAbove = null;
     let lastAbove = null;
     let moonSepAtMax = null;
+    let altAtStart = null;       // altitude at the very start of the window
+    let azAtStart = null;
 
     for (let i = 0; i < samples.length; i++) {
       const { date, moonEq } = samples[i];
@@ -514,6 +516,10 @@ app.get('/api/planner', (req, res) => {
       if (raHours == null || decDeg == null) continue;
       const pos = altAz({ raHours, decDeg, lat, lon, date });
       if (!pos) continue;
+      if (i === 0) {
+        altAtStart = pos.altitude;
+        azAtStart = pos.azimuth;
+      }
       if (pos.altitude > maxAlt) {
         maxAlt = pos.altitude;
         maxAt = date.toISOString();
@@ -535,6 +541,8 @@ app.get('/api/planner', (req, res) => {
     const minutesAbove = samplesAbove > 0 ? (samplesAbove - 1) * stepMinutes : 0;
     enriched.push({
       ...row,
+      altitude_at_start: altAtStart,
+      azimuth_at_start: azAtStart,
       max_altitude: maxAlt,
       max_altitude_at: maxAt,
       first_above_at: firstAbove,
@@ -544,7 +552,11 @@ app.get('/api/planner', (req, res) => {
     });
   }
 
-  enriched.sort((a, b) => b.max_altitude - a.max_altitude);
+  // Sort by altitude at the chosen start time, descending; targets that
+  // are already up rise to the top, ones still below the horizon at the
+  // chosen moment fall to the bottom (but stay listed because they may
+  // come up later in the window).
+  enriched.sort((a, b) => (b.altitude_at_start ?? -Infinity) - (a.altitude_at_start ?? -Infinity));
 
   res.json({
     location: { lat, lon },


### PR DESCRIPTION
## Summary
Planner now shows altitude **at the time you picked**, not just the max across the next 12 hours.

Old behaviour: set time to 11:14 PM → table sorted by max altitude reached anywhere in the next 12 h. Useful for "is M42 going to be high tonight?" planning, less useful for "what's actually up right now?".

Changes:
- `/api/planner` returns `altitude_at_start` + `azimuth_at_start` per target (the alt/az computed at the very first sample of the window).
- Targets are sorted by `altitude_at_start` descending. Below-horizon ones still appear at the bottom — they may come up later in the window, and `Above min for` still tells you how long.
- The table gains an **Alt now** column to the left of **Max alt**. Rows whose target is below the horizon at the chosen moment render dim so it's obvious at a glance.

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual: load `/planner.html`, change Time, confirm the Alt now column updates and the rows re-sort


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_