### PR TITLE
Mobile upload: fix GPS button + multi-file picker on iOS Safari

### DIFF
--- a/admin/upload.html
+++ b/admin/upload.html
@@ -27,7 +27,7 @@
 
       <section class="section">
         <div id="dropzone" class="dropzone" tabindex="0" role="button" aria-label="Upload image">
-          <input id="file-input" type="file" accept="image/*,.fit,.fits" hidden multiple />
+          <input id="file-input" type="file" accept="image/*" hidden multiple />
           <div class="dropzone-inner">
             <div class="dropzone-icon" aria-hidden="true">◎</div>
             <p><strong>Drag &amp; drop</strong> images here</p>
@@ -127,10 +127,10 @@
                 <span>Longitude</span>
                 <input id="longitude-input" name="longitude" type="number" step="any" min="-180" max="180" placeholder="-0.0005" />
               </label>
-              <label class="field" style="flex:0 0 auto; align-self:flex-end;">
-                <span>&nbsp;</span>
+              <div class="field" style="flex:0 0 auto; align-self:flex-end;">
+                <span style="display:block; visibility:hidden;">&nbsp;</span>
                 <button type="button" id="use-image-gps" class="button-link ghost-link" disabled title="Copy GPS from the image's EXIF">Use image GPS</button>
-              </label>
+              </div>
             </div>
 
             <label class="field">
@@ -206,10 +206,10 @@
             </div>
 
             <div class="row">
-              <label class="field" style="flex:0 0 auto;">
-                <span>&nbsp;</span>
+              <div class="field" style="flex:0 0 auto;">
+                <span style="display:block; visibility:hidden;">&nbsp;</span>
                 <button type="button" id="fetch-weather-btn" class="button-link ghost-link" disabled title="Fetch historical weather from Open-Meteo for this date and GPS coordinates">Fetch weather</button>
-              </label>
+              </div>
               <span id="weather-summary" class="dim" style="align-self:flex-end; padding-bottom:0.5rem;"></span>
             </div>
 


### PR DESCRIPTION
## Summary
Two iOS Safari upload-form bugs.

1. **"Use image GPS" + "Fetch weather" buttons didn't fire on mobile.** Both were wrapped in `<label class="field">` for vertical alignment with the neighbouring input rows. iOS Safari intercepts label taps and often swallows the synthetic click before it reaches the contained button. Swapped the two affected labels for plain `<div class="field">` of the same class — same visual layout, no label semantics.

2. **Multi-file picker fell back to single-pick on iOS.** The dropzone input was `accept="image/*,.fit,.fits"`. Mixing a MIME wildcard with extension hints that the iOS Photos picker doesn't recognise drops it into single-pick mode even with `multiple` set. Reduced to `accept="image/*"`; the Photos picker now shows its native multi-select UI. FITS uploads still work via desktop drag-drop (and would always have failed on iOS anyway since FITS isn't in Photos).

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual on iPhone: upload page → tap "browse your files" → multi-select works
- [ ] Manual on iPhone: drop a Seestar JPG with EXIF GPS → tap "Use image GPS" → lat/lon populate


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_