### PR TITLE
Mobile multi-pick: serialize uploads + snapshot the FileList

### DIFF
--- a/admin/upload.js
+++ b/admin/upload.js
@@ -177,7 +177,13 @@ dropzone.addEventListener('drop', (e) => {
   if (files?.length) handleFiles(files);
 });
 fileInput.addEventListener('change', () => {
-  if (fileInput.files?.length) handleFiles(fileInput.files);
+  if (!fileInput.files?.length) return;
+  // Snapshot synchronously — iOS revokes the FileList entries quickly
+  // when the picker closes — and reset the input so re-picking the same
+  // image fires change again.
+  const snapshot = Array.from(fileInput.files);
+  fileInput.value = '';
+  handleFiles(snapshot);
 });
 sidecarInput.addEventListener('change', () => {
   const file = sidecarInput.files?.[0];
@@ -230,7 +236,10 @@ async function applySidecar(file) {
   else sidecarSummary.textContent = 'Sidecar parsed but no recognised fields found.';
 }
 
-function handleFiles(files) {
+async function handleFiles(files) {
+  // Snapshot eagerly: iOS Safari's Photos picker delivers FileList entries
+  // lazily, and firing N parallel uploads against that lazy list dropped
+  // most of them on the floor with no error visible to the user.
   const list = Array.from(files);
   const json = list.find(isJsonFile);
   const captures = list.filter((f) => isImageFile(f) || isFitsFile(f));
@@ -238,9 +247,19 @@ function handleFiles(files) {
     setStatus('Drop an image, a FITS file, a Seestar .json, or any combination.', 'error');
     return;
   }
-
-  for (const file of captures) uploadStaged(file).catch(() => {});
+  // Sidecar JSON applies to whatever's currently active — apply it first so
+  // the form has its values before the first stage finishes.
   if (json) applySidecar(json);
+  // Stage one at a time. Slower than the old parallel fan-out, but it's the
+  // only pattern that works reliably with iOS multi-pick. setStatus errors
+  // are surfaced individually instead of silently swallowed.
+  for (const file of captures) {
+    try {
+      await uploadStaged(file);
+    } catch (err) {
+      setStatus(`Upload of ${file.name || 'a file'} failed: ${err.message || err}`, 'error');
+    }
+  }
 }
 
 function handleFile(file) {


### PR DESCRIPTION
## Summary
iOS Photos lets multi-select, but tapping Done did nothing — silent no-op. Two combined causes:

1. **Lazy FileList + parallel uploads.** iOS delivers the multi-pick FileList lazily and starts revoking entries when the picker closes. The old `handleFiles()` fired N parallel XHRs all reading from that same lazy FileList; most ended up reading nothing.
2. **Swallowed errors.** Failed uploads were `.catch(() => {})` so no status update appeared — the form looked unresponsive even though it had started and aborted N requests.

**Fix:**
- Snapshot the FileList synchronously inside the `change` handler (`Array.from(fileInput.files)`) and reset `fileInput.value` so re-picking the same image still fires `change`.
- Stage one file at a time in `handleFiles` (await per upload). Slower than the parallel fan-out but the only pattern that works reliably with iOS multi-pick.
- Per-file failures now surface to the status line instead of being swallowed.

Single-file uploads behave the same as before. Drag-and-drop on desktop also benefits from the snapshot + serial pattern (no more rare double-fire glitches).

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual on iPhone: tap "browse your files", multi-select 5 photos, tap Done → all 5 appear in the queue, status line shows progress
- [ ] Manual on desktop: drop 5 JPGs at once → still all queued


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_