### PR TITLE
Default observer location + 'Use this device's location' button

### DIFF
--- a/admin/dashboard.js
+++ b/admin/dashboard.js
@@ -282,27 +282,45 @@ async function loadSiteSettings() {
     if (!res.ok) return;
     const data = await res.json();
     input.value = data.site_name || '';
+    const latIn = document.getElementById('default-latitude-input');
+    const lonIn = document.getElementById('default-longitude-input');
+    if (latIn) latIn.value = data.default_latitude != null ? data.default_latitude : '';
+    if (lonIn) lonIn.value = data.default_longitude != null ? data.default_longitude : '';
   } catch { /* leave blank */ }
 }
 
 document.getElementById('settings-form')?.addEventListener('submit', async (ev) => {
   ev.preventDefault();
   const input = document.getElementById('site-name-input');
+  const latIn = document.getElementById('default-latitude-input');
+  const lonIn = document.getElementById('default-longitude-input');
   const status = document.getElementById('settings-status');
   const value = input.value.trim();
   if (!value) { status.textContent = 'Site name cannot be empty.'; return; }
+  // Both default lat/lon must be present or both blank — half-set
+  // coordinates aren't useful.
+  const latRaw = latIn?.value.trim() ?? '';
+  const lonRaw = lonIn?.value.trim() ?? '';
+  if ((latRaw === '') !== (lonRaw === '')) {
+    status.textContent = 'Set both default lat and lon, or leave both blank.';
+    return;
+  }
   status.textContent = 'Saving…';
   try {
     const res = await fetch('/api/admin/settings', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ site_name: value }),
+      body: JSON.stringify({
+        site_name: value,
+        default_latitude: latRaw === '' ? '' : Number(latRaw),
+        default_longitude: lonRaw === '' ? '' : Number(lonRaw),
+      }),
     });
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.error || `HTTP ${res.status}`);
     }
-    status.textContent = 'Saved. Refresh to see the new branding.';
+    status.textContent = 'Saved.';
   } catch (err) {
     status.textContent = `Failed: ${err.message}`;
   }

--- a/admin/index.html
+++ b/admin/index.html
@@ -91,9 +91,22 @@
             <span class="dim" style="font-size:0.85em;">Site name</span>
             <input id="site-name-input" type="text" maxlength="80" required style="min-width:18rem;" />
           </label>
+          <label style="display:flex; flex-direction:column; gap:0.25rem;">
+            <span class="dim" style="font-size:0.85em;">Default latitude</span>
+            <input id="default-latitude-input" type="number" step="any" min="-90" max="90" placeholder="51.4769" style="min-width:9rem;" />
+          </label>
+          <label style="display:flex; flex-direction:column; gap:0.25rem;">
+            <span class="dim" style="font-size:0.85em;">Default longitude</span>
+            <input id="default-longitude-input" type="number" step="any" min="-180" max="180" placeholder="-0.0005" style="min-width:9rem;" />
+          </label>
           <button type="submit" class="button-link">Save</button>
           <span id="settings-status" class="dim"></span>
         </form>
+        <p class="dim" style="margin:0.5rem 0 0; font-size:0.85em;">
+          Default location is used as a fallback when an image has no EXIF GPS
+          and the watermark OCR couldn't extract coordinates. Leave blank to
+          require manual entry instead.
+        </p>
       </section>
 
       <section class="section">

--- a/admin/upload.html
+++ b/admin/upload.html
@@ -128,6 +128,9 @@
                 <input id="longitude-input" name="longitude" type="number" step="any" min="-180" max="180" placeholder="-0.0005" />
               </label>
               <small id="gps-hint" class="dim" style="flex-basis:100%; margin-top:-0.4rem;"></small>
+              <small style="flex-basis:100%; margin-top:-0.2rem;">
+                <button type="button" id="use-device-location" class="linkish">📍 Use this device's location</button>
+              </small>
             </div>
 
             <label class="field">

--- a/admin/upload.js
+++ b/admin/upload.js
@@ -26,6 +26,16 @@ const decDegreesInput = document.getElementById('dec-degrees-input');
 const latitudeInput = document.getElementById('latitude-input');
 const longitudeInput = document.getElementById('longitude-input');
 const gpsHint = document.getElementById('gps-hint');
+const useDeviceLocationBtn = document.getElementById('use-device-location');
+
+// Fetched once on load from /api/settings. Used as a last-resort fallback
+// when EXIF and watermark OCR both fail.
+let defaultLatitude = null;
+let defaultLongitude = null;
+fetch('/api/settings').then((r) => r.ok ? r.json() : null).then((s) => {
+  if (typeof s?.default_latitude === 'number') defaultLatitude = s.default_latitude;
+  if (typeof s?.default_longitude === 'number') defaultLongitude = s.default_longitude;
+}).catch(() => {});
 const titleInput = document.getElementById('title-input');
 const telescopeSelect = document.getElementById('telescope-select');
 const telescopeHint = document.getElementById('telescope-hint');
@@ -393,13 +403,21 @@ async function onStaged(res) {
       const source = res.guesses?.from_ocr ? 'watermark OCR' : 'image EXIF';
       gpsHint.textContent = `Auto-filled from ${source} (${res.exif.latitude.toFixed(4)}, ${res.exif.longitude.toFixed(4)}).`;
     }
+  } else if (defaultLatitude != null && defaultLongitude != null) {
+    // Admin-configured default home location wins over leaving the field
+    // empty. The user can still overwrite manually for one-off remote sites.
+    latitudeInput.value = defaultLatitude.toFixed(6);
+    longitudeInput.value = defaultLongitude.toFixed(6);
+    if (gpsHint) {
+      gpsHint.textContent = `Auto-filled from saved default location (${defaultLatitude.toFixed(4)}, ${defaultLongitude.toFixed(4)}). Override above if you're imaging from somewhere else.`;
+    }
   } else if (gpsHint) {
     // Be specific about why we couldn't fill — helps the user know whether
     // to retry, switch firmware, or just type the coords by hand.
     let reason = 'No GPS in image EXIF';
     if (res.guesses?.from_ocr) reason += ' and the watermark OCR text didn\'t include readable coordinates';
     else if (res.guesses?.ocr_error) reason += ` and watermark OCR failed (${res.guesses.ocr_error})`;
-    gpsHint.textContent = `${reason} — enter coordinates manually to enable weather + Bortle lookup.`;
+    gpsHint.textContent = `${reason} — tap "Use this device's location" or enter coordinates manually.`;
   }
   if (latitudeInput.value && longitudeInput.value) {
     maybeAutoFillFromLocationHistory();
@@ -728,6 +746,32 @@ async function maybeAutoFillFromLocationHistory() {
     }
   } catch { /* best effort */ }
 }
+
+// "Use this device's location" — wraps the Geolocation API, fills the
+// lat/lon inputs from the browser, and kicks the same auto-fetches the
+// inputs would fire via input/change. Most useful on phones (~5 m).
+useDeviceLocationBtn?.addEventListener('click', () => {
+  if (!navigator.geolocation) {
+    if (gpsHint) gpsHint.textContent = 'Geolocation API not available in this browser.';
+    return;
+  }
+  if (gpsHint) gpsHint.textContent = 'Requesting location…';
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      latitudeInput.value = pos.coords.latitude.toFixed(6);
+      longitudeInput.value = pos.coords.longitude.toFixed(6);
+      if (gpsHint) {
+        gpsHint.textContent = `Auto-filled from device GPS (${pos.coords.latitude.toFixed(4)}, ${pos.coords.longitude.toFixed(4)}, ±${Math.round(pos.coords.accuracy)} m).`;
+      }
+      maybeAutoFillFromLocationHistory();
+      if (dateInput.value) maybeAutoFetchWeather();
+    },
+    (err) => {
+      if (gpsHint) gpsHint.textContent = `Geolocation failed: ${err.message}.`;
+    },
+    { enableHighAccuracy: true, timeout: 10_000 },
+  );
+});
 
 // Bortle ↔ SQM conversion. The mapping is the canonical Bortle/SQM scale
 // used by darksitefinder.com / Sky Quality Meters; we pick the centre of

--- a/server.js
+++ b/server.js
@@ -1074,6 +1074,9 @@ app.get('/api/settings', (_req, res) => {
   const rows = db.prepare(`SELECT key, value FROM site_settings`).all();
   const out = { site_name: 'DeepSkyLog' };
   for (const r of rows) out[r.key] = r.value;
+  // Coerce known numeric keys for the client's convenience.
+  if (out.default_latitude != null) out.default_latitude = Number(out.default_latitude);
+  if (out.default_longitude != null) out.default_longitude = Number(out.default_longitude);
   res.json(out);
 });
 
@@ -1085,6 +1088,30 @@ app.put('/api/admin/settings', basicAuth, (req, res) => {
     if (!trimmed) return res.status(400).json({ error: 'site_name cannot be empty' });
     if (trimmed.length > 80) return res.status(400).json({ error: 'site_name max 80 chars' });
     updates.push(['site_name', trimmed]);
+  }
+  // Default observer location — auto-applied when EXIF/OCR don't yield
+  // coordinates. Empty string clears it.
+  if ('default_latitude' in body) {
+    const v = body.default_latitude;
+    if (v === '' || v === null) updates.push(['default_latitude', '']);
+    else {
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < -90 || n > 90) {
+        return res.status(400).json({ error: 'default_latitude must be a number between -90 and 90' });
+      }
+      updates.push(['default_latitude', String(n)]);
+    }
+  }
+  if ('default_longitude' in body) {
+    const v = body.default_longitude;
+    if (v === '' || v === null) updates.push(['default_longitude', '']);
+    else {
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < -180 || n > 180) {
+        return res.status(400).json({ error: 'default_longitude must be a number between -180 and 180' });
+      }
+      updates.push(['default_longitude', String(n)]);
+    }
   }
   if (!updates.length) return res.status(400).json({ error: 'no settings to update' });
   const stmt = db.prepare(


### PR DESCRIPTION
## Summary
OCR'ing the Seestar watermark works most of the time but isn't 100% — faint band, dropped degree glyphs, etc. Adding two more reliable lat/lon sources so the fields stop coming up empty.

### 1. Default home location in admin settings
Two new fields on the existing Site Settings form (Default latitude / Default longitude). Saved in `site_settings`; clearable by blanking. Upload form pulls them from `/api/settings` on load and uses them when EXIF and OCR both miss. Hint reads `Auto-filled from saved default location (51.4769, -0.0005). Override above if you're imaging from somewhere else.`

### 2. "Use this device's location" link
Sits under the lat/lon row on the upload form. Uses `navigator.geolocation` (`enableHighAccuracy: true`, 10 s timeout). On phones it's typically <1 s and ~5 m accurate. Hint reports the accuracy radius. Plays nicely with the existing auto-weather and Bortle-from-history fetches — they fire after the link populates the inputs.

### Server
`/api/admin/settings` learns `default_latitude` / `default_longitude` (numeric, bounds-checked, empty-string clears). `/api/settings` (public) returns them as numbers when set.

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual: set default lat/lon in admin → upload an image with no GPS → lat/lon auto-fill from defaults
- [ ] Manual on phone: tap "Use this device's location" → lat/lon populate from device GPS
- [ ] Manual: clear default lat/lon → revert to "no GPS in image EXIF…" hint


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_