### PR TITLE
Upload: fix 'Use this device's location' link styling on mobile

### DIFF
--- a/admin/upload.html
+++ b/admin/upload.html
@@ -128,9 +128,12 @@
                 <input id="longitude-input" name="longitude" type="number" step="any" min="-180" max="180" placeholder="-0.0005" />
               </label>
               <small id="gps-hint" class="dim" style="flex-basis:100%; margin-top:-0.4rem;"></small>
-              <small style="flex-basis:100%; margin-top:-0.2rem;">
-                <button type="button" id="use-device-location" class="linkish">📍 Use this device's location</button>
-              </small>
+              <div style="flex-basis:100%;">
+                <button type="button" id="use-device-location"
+                        style="background:none; border:none; color:var(--accent); padding:0; font-size:0.85rem; text-transform:none; letter-spacing:normal; text-decoration:underline; cursor:pointer;">
+                  📍 Use this device's location
+                </button>
+              </div>
             </div>
 
             <label class="field">


### PR DESCRIPTION
## Summary
The "📍 Use this device's location" button rendered as a wide orange bar on mobile with only the pin visible — the rest of the label was off-screen. Cause: `class="linkish"` applies `text-transform: uppercase` + `letter-spacing: 0.1em` + `text-decoration: underline`, which made the upper-cased label wider than the viewport.

Replaced the class with inline styles tuned for an unobtrusive inline link (normal case, normal spacing, simple underline) and pulled the button out of the `<small>` wrapper so font sizing is predictable. Functionality unchanged — the click handler still drives geolocation.

## Test plan
- [x] `npm test` (smoke) green: 29/29
- [ ] Manual on iPhone: upload page → link reads "📍 Use this device's location" in normal case → tapping populates lat/lon


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_