### PR TITLE
Add Seestar session planner — one target per hour, zenith-safe

### DIFF
--- a/public/gallery.html
+++ b/public/gallery.html
@@ -16,6 +16,7 @@
         <a href="/" data-nav="home">Dashboard</a>
         <a href="/tonight.html" data-nav="tonight">Tonight</a>
         <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/seestar.html" data-nav="seestar">Seestar planner</a>
         <a href="/gallery.html" data-nav="gallery">Gallery</a>
         <a href="/map.html" data-nav="map">Map</a>
       </nav>

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
         <a href="/" data-nav="home">Dashboard</a>
         <a href="/tonight.html" data-nav="tonight">Tonight</a>
         <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/seestar.html" data-nav="seestar">Seestar planner</a>
         <a href="/gallery.html" data-nav="gallery">Gallery</a>
         <a href="/map.html" data-nav="map">Map</a>
       </nav>

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -1,0 +1,134 @@
+import { fetchJson, el, typeLabel, highlightNav } from './common.js';
+
+highlightNav('seestar');
+
+const latInput = document.getElementById('lat-input');
+const lonInput = document.getElementById('lon-input');
+const minAltInput = document.getElementById('min-alt-input');
+const maxAltInput = document.getElementById('max-alt-input');
+const includeObserved = document.getElementById('include-observed');
+const locateBtn = document.getElementById('locate-btn');
+const runBtn = document.getElementById('run-btn');
+const status = document.getElementById('status');
+const moonLine = document.getElementById('moon-line');
+const windowLine = document.getElementById('window-line');
+const rows = document.getElementById('rows');
+
+const STORE_KEY = 'deepskylog.location';
+let stored = null;
+try { stored = JSON.parse(localStorage.getItem(STORE_KEY) || 'null'); }
+catch { /* corrupt — ignore */ }
+if (stored && Number.isFinite(Number(stored.lat)) && Number.isFinite(Number(stored.lon))) {
+  latInput.value = stored.lat;
+  lonInput.value = stored.lon;
+}
+
+function fmtDeg(v) { return v == null ? '—' : `${v.toFixed(1)}°`; }
+function fmtTime(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+async function load() {
+  const lat = Number(latInput.value);
+  const lon = Number(lonInput.value);
+  const minAlt = Number(minAltInput.value);
+  const maxAlt = Number(maxAltInput.value);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    status.textContent = 'Enter latitude and longitude (or tap Use my location).';
+    return;
+  }
+  if (!Number.isFinite(minAlt) || !Number.isFinite(maxAlt) || minAlt >= maxAlt) {
+    status.textContent = 'Min altitude must be less than max altitude.';
+    return;
+  }
+  localStorage.setItem(STORE_KEY, JSON.stringify({ lat, lon }));
+
+  status.textContent = 'Planning…';
+  rows.innerHTML = '';
+  const params = new URLSearchParams({
+    lat: String(lat), lon: String(lon),
+    min_alt: String(minAlt), max_alt: String(maxAlt),
+    // Start is always "now" — that's the whole point of the page.
+    start: new Date().toISOString(),
+  });
+  if (includeObserved.checked) params.set('include_observed', '1');
+
+  let data;
+  try {
+    data = await fetchJson(`/api/seestar-planner?${params}`);
+  } catch (err) {
+    status.textContent = `Failed: ${err.message}`;
+    return;
+  }
+
+  const moonPct = (data.moon.illumination * 100).toFixed(0);
+  moonLine.textContent = `Moon at start: ${data.moon.name} (${moonPct}% illuminated)`;
+
+  const start = new Date(data.window.start);
+  const end = new Date(data.window.end);
+  const sunrise = data.sunrise ? new Date(data.sunrise) : null;
+  windowLine.textContent = sunrise
+    ? `Session: ${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} – ${end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} (sunrise ${sunrise.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })})`
+    : `Session: ${start.toLocaleString()} → ${end.toLocaleString()} (sun never sets in this window)`;
+
+  const filled = data.slots.filter((s) => s.target).length;
+  status.textContent = `${filled} of ${data.slots.length} slot${data.slots.length === 1 ? '' : 's'} filled`;
+
+  if (!data.slots.length) {
+    rows.appendChild(el('tr', {}, el('td', { colspan: '10' },
+      el('div', { class: 'empty-state', text: 'No imaging window — sunrise is within the next hour.' }))));
+    return;
+  }
+
+  for (const slot of data.slots) {
+    const slotLabel = `${fmtTime(slot.slot_start)} – ${fmtTime(slot.slot_end)}`;
+    if (!slot.target) {
+      rows.appendChild(el('tr', { class: 'dim' },
+        el('td', { text: slotLabel }),
+        el('td', { colspan: '9', class: 'empty-state', text: 'No target in altitude range that hasn\'t been used yet.' }),
+      ));
+      continue;
+    }
+    const t = slot.target;
+    rows.appendChild(el('tr', { class: t.observed ? 'observed' : '' },
+      el('td', { text: slotLabel }),
+      el('td', {}, el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
+      el('td', { text: t.name || '—' }),
+      el('td', { text: typeLabel(t.object_type) }),
+      el('td', { text: t.constellation || '—' }),
+      el('td', { text: t.magnitude != null ? Number(t.magnitude).toFixed(1) : '—' }),
+      el('td', { text: fmtDeg(t.altitude_at_start) }),
+      el('td', { text: fmtDeg(t.altitude_at_end) }),
+      el('td', { text: fmtDeg(t.azimuth_at_start) }),
+      el('td', { class: 'dim list-cell', text: t.list_name }),
+    ));
+  }
+}
+
+locateBtn.addEventListener('click', () => {
+  if (!navigator.geolocation) {
+    status.textContent = 'Geolocation is not available.';
+    return;
+  }
+  status.textContent = 'Requesting location…';
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      latInput.value = pos.coords.latitude.toFixed(4);
+      lonInput.value = pos.coords.longitude.toFixed(4);
+      load();
+    },
+    (err) => { status.textContent = `Geolocation failed: ${err.message}`; },
+    { enableHighAccuracy: true, timeout: 10000 },
+  );
+});
+
+runBtn.addEventListener('click', load);
+
+// Auto-run on page load if we already have coords cached. The user
+// expects the page to "just work" given the goal — a one-tap Seestar
+// session plan.
+if (Number.isFinite(Number(latInput.value)) && Number.isFinite(Number(lonInput.value))) {
+  load();
+}

--- a/public/list.html
+++ b/public/list.html
@@ -16,6 +16,7 @@
         <a href="/" data-nav="home">Dashboard</a>
         <a href="/tonight.html" data-nav="tonight">Tonight</a>
         <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/seestar.html" data-nav="seestar">Seestar planner</a>
         <a href="/gallery.html" data-nav="gallery">Gallery</a>
         <a href="/map.html" data-nav="map">Map</a>
       </nav>

--- a/public/map.html
+++ b/public/map.html
@@ -46,6 +46,7 @@
         <a href="/" data-nav="home">Dashboard</a>
         <a href="/tonight.html" data-nav="tonight">Tonight</a>
         <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/seestar.html" data-nav="seestar">Seestar planner</a>
         <a href="/gallery.html" data-nav="gallery">Gallery</a>
         <a href="/map.html" data-nav="map">Map</a>
       </nav>

--- a/public/object.html
+++ b/public/object.html
@@ -18,6 +18,7 @@
         <a href="/" data-nav="home">Dashboard</a>
         <a href="/tonight.html" data-nav="tonight">Tonight</a>
         <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/seestar.html" data-nav="seestar">Seestar planner</a>
         <a href="/gallery.html" data-nav="gallery">Gallery</a>
         <a href="/map.html" data-nav="map">Map</a>
       </nav>

--- a/public/observation.html
+++ b/public/observation.html
@@ -31,6 +31,7 @@
         <a href="/" data-nav="home">Dashboard</a>
         <a href="/tonight.html" data-nav="tonight">Tonight</a>
         <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/seestar.html" data-nav="seestar">Seestar planner</a>
         <a href="/gallery.html" data-nav="gallery">Gallery</a>
         <a href="/map.html" data-nav="map">Map</a>
       </nav>

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>DeepSkyLog &mdash; Session Planner</title>
+    <title>DeepSkyLog &mdash; Seestar Planner</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -22,33 +22,25 @@
       </nav>
     </header>
     <main>
-      <h1 class="page-title">Session planner</h1>
-      <p class="page-subtitle" id="subtitle">Pick a date, time and your location, see which unobserved targets clear your minimum altitude — and for how long.</p>
+      <h1 class="page-title">Seestar session planner</h1>
+      <p class="page-subtitle" id="subtitle">One target per hour from now until an hour before sunrise. Each pick is above your minimum altitude at the slot start, and stays under the zenith-avoidance ceiling by the slot end.</p>
 
       <div class="toolbar">
         <label>
-          Date
-          <input id="date-input" type="date" />
-        </label>
-        <label>
-          Time
-          <input id="time-input" type="time" />
-        </label>
-        <label>
           Latitude
-          <input id="lat-input" type="number" step="0.0001" placeholder="51.4769" />
+          <input id="lat-input" type="number" step="any" placeholder="51.4769" />
         </label>
         <label>
           Longitude
-          <input id="lon-input" type="number" step="0.0001" placeholder="-0.0005" />
+          <input id="lon-input" type="number" step="any" placeholder="-0.0005" />
         </label>
         <label>
           Min altitude (°)
-          <input id="alt-input" type="number" step="1" min="0" max="90" value="30" />
+          <input id="min-alt-input" type="number" step="1" min="0" max="90" value="50" />
         </label>
-        <label title="Hide targets within this many degrees of the moon at their best altitude">
-          Min moon sep (°)
-          <input id="moon-sep-input" type="number" step="1" min="0" max="180" value="0" />
+        <label>
+          Max altitude (°)
+          <input id="max-alt-input" type="number" step="1" min="0" max="90" value="80" />
         </label>
         <label>
           <input id="include-observed" type="checkbox" /> Include observed
@@ -59,30 +51,29 @@
       </div>
 
       <div id="moon-line" class="dim" style="margin-bottom: 0.25rem;"></div>
-      <div id="bands-line" class="dim" style="margin-bottom: 0.75rem;"></div>
+      <div id="window-line" class="dim" style="margin-bottom: 0.75rem;"></div>
 
       <div class="table-wrapper">
         <table>
           <thead>
-            <tr id="planner-head">
-              <th data-sort="object">Object</th>
-              <th data-sort="name">Name</th>
-              <th data-sort="type">Type</th>
-              <th data-sort="constellation">Constellation</th>
-              <th data-sort="magnitude">Mag</th>
-              <th data-sort="alt_now">Alt now</th>
-              <th data-sort="max_alt">Max alt</th>
-              <th data-sort="max_alt_at">At</th>
-              <th data-sort="above_min">Above min for</th>
-              <th data-sort="moon_sep">Moon Δ</th>
-              <th data-sort="list">List</th>
+            <tr>
+              <th>Slot</th>
+              <th>Object</th>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Constellation</th>
+              <th>Mag</th>
+              <th>Alt start</th>
+              <th>Alt end</th>
+              <th>Az start</th>
+              <th>List</th>
             </tr>
           </thead>
           <tbody id="rows"></tbody>
         </table>
       </div>
     </main>
-    <script type="module" src="/js/planner.js"></script>
+    <script type="module" src="/js/seestar-plan.js"></script>
     <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/tonight.html
+++ b/public/tonight.html
@@ -16,6 +16,7 @@
         <a href="/" data-nav="home">Dashboard</a>
         <a href="/tonight.html" data-nav="tonight">Tonight</a>
         <a href="/planner.html" data-nav="planner">Planner</a>
+        <a href="/seestar.html" data-nav="seestar">Seestar planner</a>
         <a href="/gallery.html" data-nav="gallery">Gallery</a>
         <a href="/map.html" data-nav="map">Map</a>
       </nav>

--- a/server.js
+++ b/server.js
@@ -570,6 +570,146 @@ app.get('/api/planner', (req, res) => {
   });
 });
 
+// Seestar session planner: from a chosen start time, hand out one target
+// per hour-long slot, stopping an hour before sunrise. Each target is
+// picked to be 'safe for a Seestar' — at slot start its altitude is at
+// least min_alt (default 50°), and at slot end it's no higher than
+// max_alt (default 80°) so the tube doesn't have to swing through
+// zenith. Each target is assigned to at most one slot.
+app.get('/api/seestar-planner', (req, res) => {
+  const lat = Number(req.query.lat);
+  const lon = Number(req.query.lon);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return res.status(400).json({ error: 'lat and lon query params are required' });
+  }
+  const minAlt = Number.isFinite(Number(req.query.min_alt)) ? Number(req.query.min_alt) : 50;
+  const maxAlt = Number.isFinite(Number(req.query.max_alt)) ? Number(req.query.max_alt) : 80;
+  const includeObserved = req.query.include_observed === '1';
+  const start = req.query.start ? new Date(req.query.start) : new Date();
+  if (Number.isNaN(start.getTime())) {
+    return res.status(400).json({ error: 'invalid start time' });
+  }
+
+  // Find the next sunrise (sun altitude crossing 0 from below). Scan
+  // hour-by-hour up to 36 h ahead; refine to the nearest minute. If the
+  // sun never sets in this 36 h window (high-latitude summer) we cap the
+  // session at start + 12 h so the table doesn't run forever.
+  function sunAltAt(date) {
+    const eq = sunPosition(date);
+    const pos = altAz({ raHours: eq.raHours, decDeg: eq.decDeg, lat, lon, date });
+    return pos?.altitude ?? 0;
+  }
+  let sunrise = null;
+  let prev = sunAltAt(start);
+  for (let h = 1; h <= 36; h++) {
+    const t = new Date(start.getTime() + h * 3_600_000);
+    const cur = sunAltAt(t);
+    if (prev < 0 && cur >= 0) {
+      // Refine to the nearest minute.
+      let lo = new Date(t.getTime() - 3_600_000);
+      let hi = t;
+      for (let i = 0; i < 60; i++) {
+        const mid = new Date((lo.getTime() + hi.getTime()) / 2);
+        if (sunAltAt(mid) >= 0) hi = mid; else lo = mid;
+      }
+      sunrise = hi;
+      break;
+    }
+    prev = cur;
+  }
+  const sessionEnd = sunrise
+    ? new Date(sunrise.getTime() - 3_600_000)
+    : new Date(start.getTime() + 12 * 3_600_000);
+
+  // Slot grid: start, +1h, +2h, … each slot is start→start+1h. We don't
+  // start a new slot whose start ≥ sessionEnd.
+  const slots = [];
+  for (let t = start.getTime(); t < sessionEnd.getTime(); t += 3_600_000) {
+    slots.push({ start: new Date(t), end: new Date(t + 3_600_000) });
+  }
+
+  // Pull every list_object that has either coordinates or an ephemeris
+  // we can compute live (same predicate as /api/planner).
+  const rows = db
+    .prepare(
+      `SELECT lo.id, lo.catalog, lo.catalog_number, lo.name, lo.object_type,
+              lo.constellation, lo.ra_hours, lo.dec_degrees, lo.magnitude,
+              lo.ephemeris,
+              l.slug AS list_slug, l.name AS list_name,
+              EXISTS(SELECT 1 FROM list_completions lc
+                       WHERE lc.list_object_id = lo.id) AS observed
+         FROM list_objects lo
+         JOIN lists l ON l.id = lo.list_id
+         WHERE lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
+            OR lo.ephemeris IS NOT NULL`,
+    )
+    .all();
+
+  function coordsAt(row, date) {
+    if (row.ephemeris) {
+      const eph = bodyPosition(row.ephemeris, date);
+      if (!eph) return null;
+      return { raHours: eph.raHours, decDeg: eph.decDeg };
+    }
+    if (row.ra_hours == null || row.dec_degrees == null) return null;
+    return { raHours: row.ra_hours, decDeg: row.dec_degrees };
+  }
+
+  const assignedIds = new Set();
+  const plan = slots.map((slot) => {
+    // Score every eligible target for this slot and take the best one.
+    let best = null;
+    for (const row of rows) {
+      if (!includeObserved && row.observed) continue;
+      if (assignedIds.has(row.id)) continue;
+      const eqStart = coordsAt(row, slot.start);
+      const eqEnd = coordsAt(row, slot.end);
+      if (!eqStart || !eqEnd) continue;
+      const posStart = altAz({ ...eqStart, lat, lon, date: slot.start });
+      const posEnd = altAz({ ...eqEnd, lat, lon, date: slot.end });
+      if (!posStart || !posEnd) continue;
+      if (posStart.altitude < minAlt) continue;
+      if (posEnd.altitude > maxAlt) continue;
+      // Prefer the target that's lowest at start (most window to climb)
+      // but still above min_alt — keeps zenith-bound targets for later
+      // slots when they're more useful. Tie-break on brightness.
+      const score = -posStart.altitude * 1000 - (row.magnitude ?? 99);
+      if (!best || score > best.score) {
+        best = { row, posStart, posEnd, score };
+      }
+    }
+    if (!best) return { ...{ slot_start: slot.start.toISOString(), slot_end: slot.end.toISOString() }, target: null };
+    assignedIds.add(best.row.id);
+    const { row, posStart, posEnd } = best;
+    return {
+      slot_start: slot.start.toISOString(),
+      slot_end: slot.end.toISOString(),
+      target: {
+        id: row.id,
+        catalog: row.catalog, catalog_number: row.catalog_number,
+        name: row.name, object_type: row.object_type, constellation: row.constellation,
+        magnitude: row.magnitude,
+        list_slug: row.list_slug, list_name: row.list_name,
+        observed: !!row.observed,
+        altitude_at_start: posStart.altitude,
+        altitude_at_end: posEnd.altitude,
+        azimuth_at_start: posStart.azimuth,
+        azimuth_at_end: posEnd.azimuth,
+      },
+    };
+  });
+
+  res.json({
+    location: { lat, lon },
+    window: { start: start.toISOString(), end: sessionEnd.toISOString() },
+    sunrise: sunrise ? sunrise.toISOString() : null,
+    min_altitude: minAlt,
+    max_altitude: maxAlt,
+    moon: moonPhase(start),
+    slots: plan,
+  });
+});
+
 app.get('/api/tonight', (req, res) => {
   const lat = Number(req.query.lat);
   const lon = Number(req.query.lon);

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -707,6 +707,34 @@ test('smoke', async (t) => {
     assert.equal(pruned.targets.length, 0);
   });
 
+  await t.test('Seestar planner returns hourly slots respecting alt window', async () => {
+    // Pick a start far from sunrise at the target location so we always
+    // get a non-trivial slot list. Start at 2026-01-15 22:00 UTC,
+    // observer at (51.5, 0) — guaranteed dark night in January.
+    const start = new Date('2026-01-15T22:00:00Z').toISOString();
+    const data = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&min_alt=50&max_alt=80`,
+    );
+    assert.ok(Array.isArray(data.slots), 'slots present');
+    assert.ok(data.slots.length >= 4, `expected several hourly slots, got ${data.slots.length}`);
+    // Sunrise should be in the morning.
+    assert.ok(data.sunrise, 'sunrise computed');
+    // Window end = sunrise - 1h.
+    const end = new Date(data.window.end).getTime();
+    const sunrise = new Date(data.sunrise).getTime();
+    assert.equal(sunrise - end, 3_600_000, 'window ends an hour before sunrise');
+    // Every assigned target must be in the [50, 80] window at slot start
+    // and end, and no target may be assigned twice.
+    const seen = new Set();
+    for (const s of data.slots) {
+      if (!s.target) continue;
+      assert.ok(!seen.has(s.target.id), `target ${s.target.id} assigned twice`);
+      seen.add(s.target.id);
+      assert.ok(s.target.altitude_at_start >= 50, 'alt_start >= min');
+      assert.ok(s.target.altitude_at_end <= 80, 'alt_end <= max');
+    }
+  });
+
   await t.test('NGC fallback resolves common designations', async () => {
     const res = await fetch(`${baseUrl}/api/admin/objects/lookup?q=NGC7000`, {
       headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },


### PR DESCRIPTION
## Summary
New `/seestar.html` page, linked in the nav between **Planner** and **Gallery**. The goal: open the page and get a printable session plan for the rest of the night without having to think.

### How it works
- Start time is **now** (no date/time inputs — that's the whole point).
- Lat/lon are editable, default to whatever's in `localStorage` from the regular Planner, and there's a **Use my location** button (high-accuracy geolocation, same pattern as the upload form).
- One target per hour-long slot, from now until **one hour before sunrise**.
- Each target picked satisfies: `altitude_at_slot_start ≥ min_alt` (default **50°**) and `altitude_at_slot_end ≤ max_alt` (default **80°**) — keeps the Seestar tube away from zenith where tracking is flaky.
- Same `Include observed` toggle as the Session Planner.
- Each target is assigned at most one slot; the picker prefers the **lowest** qualifying `alt_start` so zenith-bound targets are saved for later slots (where they're actually useful) and ties break on brightness.

### Server
- New `GET /api/seestar-planner?lat=&lon=&start=&min_alt=&max_alt=&include_observed=`.
- Computes the next sunrise via 1 h scan + minute-level binary search; session ends one hour before sunrise (or `start + 12 h` if the sun never sets — high-latitude summer).
- Returns `{ window, sunrise, moon, slots: [{slot_start, slot_end, target?}] }`.

### Tests
+1 smoke: starts at 2026-01-15 22:00 UTC at (51.5, 0), expects ≥4 hourly slots, sunrise math correct (`window.end == sunrise - 1h`), no duplicate targets, every assigned target's `alt_start ≥ 50` and `alt_end ≤ 80`.

## Test plan
- [x] `npm test` green: 30/30
- [ ] Manual: open `/seestar.html`, tap Use my location, see a full slate of hourly targets


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_