### PR TITLE
Catalog filter shared across Planner, Seestar planner, Tonight

### DIFF
--- a/public/js/catalog-filter.js
+++ b/public/js/catalog-filter.js
@@ -1,0 +1,90 @@
+// Shared catalog-filter UI used by /planner.html, /seestar.html and
+// /tonight.html. Renders a <details> drop-down of checkboxes for each
+// seeded list; the selection persists in localStorage so picking
+// Messier + Caldwell on the planner page carries over to the Seestar
+// planner. Empty selection (all unchecked) means "no filter — show
+// every list", matching the server's default behaviour.
+
+import { fetchJson, el } from './common.js';
+
+const STORE_KEY = 'deepskylog.catalog_filter';
+
+function loadStored() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORE_KEY) || 'null');
+    return Array.isArray(raw) ? raw : null;
+  } catch { return null; }
+}
+
+function storeSelection(slugs) {
+  try {
+    localStorage.setItem(STORE_KEY, JSON.stringify(slugs));
+  } catch { /* private mode, ignore */ }
+}
+
+// Render the filter into `container`. Calls `onChange()` whenever the
+// user toggles a checkbox. Returns a function that fetches the current
+// selection as an array of slugs.
+export async function mountCatalogFilter(container, onChange) {
+  let lists;
+  try {
+    lists = await fetchJson('/api/lists');
+  } catch {
+    container.appendChild(el('span', { class: 'dim', text: 'Catalog filter unavailable.' }));
+    return () => [];
+  }
+  const stored = loadStored();
+  // First-time use: every catalog is checked, equivalent to "no filter".
+  const startSelection = stored == null
+    ? lists.map((l) => l.slug)
+    : stored.filter((s) => lists.some((l) => l.slug === s));
+
+  const summary = el('summary', { style: 'cursor:pointer; padding:0.1rem 0.3rem;' });
+  const summaryLabel = document.createTextNode('');
+  summary.appendChild(summaryLabel);
+
+  const grid = el('div', {
+    style: 'display:grid; grid-template-columns:repeat(auto-fill, minmax(11rem, 1fr)); gap:0.2rem 0.6rem; padding:0.4rem 0.6rem; background:#1a0f08; border:1px solid var(--accent); border-radius:6px; margin-top:0.25rem;',
+  });
+
+  const checkboxes = [];
+  for (const l of lists) {
+    const cb = el('input', { type: 'checkbox', value: l.slug });
+    if (startSelection.includes(l.slug)) cb.checked = true;
+    cb.addEventListener('change', () => {
+      const selection = checkboxes.filter((c) => c.checked).map((c) => c.value);
+      storeSelection(selection);
+      updateSummary();
+      if (onChange) onChange();
+    });
+    checkboxes.push(cb);
+    const label = el('label', { style: 'display:flex; gap:0.4rem; align-items:center; font-size:0.85rem; color:var(--fg); text-transform:none; letter-spacing:0; font-weight:400;' });
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(` ${l.name}`));
+    grid.appendChild(label);
+  }
+
+  function updateSummary() {
+    const n = checkboxes.filter((c) => c.checked).length;
+    const total = checkboxes.length;
+    summaryLabel.data = `Catalogs (${n === total || n === 0 ? 'all' : `${n}/${total}`}) ▾`;
+  }
+  updateSummary();
+
+  const details = el('details', { style: 'min-width:0;' });
+  details.appendChild(summary);
+  details.appendChild(grid);
+  container.appendChild(details);
+
+  return function getSelection() {
+    const selected = checkboxes.filter((c) => c.checked).map((c) => c.value);
+    // All-checked is the same query as no-filter; send no param to keep
+    // the URL clean and the server fast-path.
+    if (selected.length === 0 || selected.length === checkboxes.length) return [];
+    return selected;
+  };
+}
+
+export function selectionToParam(slugs) {
+  return slugs.length ? slugs.join(',') : '';
+}

--- a/public/js/planner.js
+++ b/public/js/planner.js
@@ -1,6 +1,19 @@
 import { fetchJson, el, typeLabel, highlightNav } from './common.js';
+import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
 
 highlightNav('planner');
+
+let getCatalogSelection = () => [];
+mountCatalogFilter(document.getElementById('catalog-filter'), () => {
+  // Re-plan automatically when the catalog set changes — the user
+  // would otherwise have to tap Plan again.
+  load();
+}).then((fn) => {
+  getCatalogSelection = fn;
+  // If the page auto-ran load() before the filter was ready, re-run
+  // now that we know which catalogs the user wants.
+  if (rows.children.length) load();
+});
 
 const dateInput = document.getElementById('date-input');
 const timeInput = document.getElementById('time-input');
@@ -111,6 +124,8 @@ async function load() {
     min_alt: String(minAlt),
   });
   if (minMoonSep > 0) params.set('min_moon_sep', String(minMoonSep));
+  const catParam = selectionToParam(getCatalogSelection());
+  if (catParam) params.set('lists', catParam);
   if (time) {
     // Combine date+time as local — the resulting Date is correct UTC instant.
     const start = new Date(`${date}T${time}`);

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -1,6 +1,15 @@
 import { fetchJson, el, typeLabel, highlightNav } from './common.js';
+import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
 
 highlightNav('seestar');
+
+let getCatalogSelection = () => [];
+mountCatalogFilter(document.getElementById('catalog-filter'), () => {
+  load();
+}).then((fn) => {
+  getCatalogSelection = fn;
+  if (rows.children.length) load();
+});
 
 const latInput = document.getElementById('lat-input');
 const lonInput = document.getElementById('lon-input');
@@ -54,6 +63,8 @@ async function load() {
     start: new Date().toISOString(),
   });
   if (includeObserved.checked) params.set('include_observed', '1');
+  const catParam = selectionToParam(getCatalogSelection());
+  if (catParam) params.set('lists', catParam);
 
   let data;
   try {

--- a/public/js/tonight.js
+++ b/public/js/tonight.js
@@ -1,6 +1,15 @@
 import { fetchJson, el, typeLabel, highlightNav } from './common.js';
+import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
 
 highlightNav('tonight');
+
+let getCatalogSelection = () => [];
+mountCatalogFilter(document.getElementById('catalog-filter'), () => {
+  load();
+}).then((fn) => {
+  getCatalogSelection = fn;
+  if (rows.children.length) load();
+});
 
 const latInput = document.getElementById('lat-input');
 const lonInput = document.getElementById('lon-input');
@@ -48,6 +57,8 @@ async function load() {
     min_alt: String(minAlt),
   });
   if (includeObserved.checked) params.set('include_observed', '1');
+  const catParam = selectionToParam(getCatalogSelection());
+  if (catParam) params.set('lists', catParam);
 
   let data;
   try {

--- a/public/planner.html
+++ b/public/planner.html
@@ -53,6 +53,7 @@
         <label>
           <input id="include-observed" type="checkbox" /> Include observed
         </label>
+        <span id="catalog-filter"></span>
         <button type="button" id="locate-btn">Use my location</button>
         <button type="button" id="run-btn">Plan</button>
         <span id="status" class="dim" style="margin-left:auto;"></span>

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -45,6 +45,7 @@
         <label>
           <input id="include-observed" type="checkbox" /> Include observed
         </label>
+        <span id="catalog-filter"></span>
         <button type="button" id="locate-btn">Use my location</button>
         <button type="button" id="run-btn">Plan</button>
         <span id="status" class="dim" style="margin-left:auto;"></span>

--- a/public/tonight.html
+++ b/public/tonight.html
@@ -41,6 +41,7 @@
         <label>
           <input id="include-observed" type="checkbox" /> Include observed
         </label>
+        <span id="catalog-filter"></span>
         <button type="button" id="locate-btn">Use my location</button>
         <button type="button" id="refresh-btn">Refresh</button>
         <span id="status" class="dim" style="margin-left:auto;"></span>

--- a/server.js
+++ b/server.js
@@ -398,6 +398,20 @@ app.get('/api/observations', (req, res) => {
 //   max_altitude / max_altitude_at — the apex
 //   above_min_minutes — minutes the target is above min_alt
 //   rises_at / sets_at / window_start / window_end (relative to query)
+// Parse a comma-separated `lists` query param into an array of validated
+// list slugs. Empty / missing / unrecognised entries are dropped; an empty
+// final array means "no filter — include everything", to keep the no-arg
+// case behaving exactly as before.
+function parseListSlugFilter(raw) {
+  if (!raw) return [];
+  const wanted = String(raw).split(',').map((s) => s.trim()).filter(Boolean);
+  if (!wanted.length) return [];
+  const valid = new Set(
+    db.prepare('SELECT slug FROM lists').all().map((r) => r.slug),
+  );
+  return wanted.filter((s) => valid.has(s));
+}
+
 app.get('/api/planner', (req, res) => {
   const lat = Number(req.query.lat);
   const lon = Number(req.query.lon);
@@ -435,6 +449,12 @@ app.get('/api/planner', (req, res) => {
   const stepMinutes = Math.max(1, Math.min(60, Number(req.query.step_minutes) || 10));
   const stepMs = stepMinutes * 60_000;
 
+  // Optional catalog filter — restrict to specific list slugs.
+  const listSlugs = parseListSlugFilter(req.query.lists);
+  const listClause = listSlugs.length
+    ? `AND l.slug IN (${listSlugs.map(() => '?').join(',')})`
+    : '';
+
   const rows = db
     .prepare(
       `SELECT lo.id, lo.catalog, lo.catalog_number, lo.name, lo.object_type,
@@ -445,10 +465,11 @@ app.get('/api/planner', (req, res) => {
                        WHERE lc.list_object_id = lo.id) AS observed
          FROM list_objects lo
          JOIN lists l ON l.id = lo.list_id
-         WHERE lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
-            OR lo.ephemeris IS NOT NULL`,
+         WHERE (lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
+            OR lo.ephemeris IS NOT NULL)
+           ${listClause}`,
     )
-    .all();
+    .all(...listSlugs);
 
   // Pre-compute sun and moon position+altitude across the window. Used for
   // both target-vs-moon separation and the twilight/moon-up bands surfaced
@@ -629,7 +650,12 @@ app.get('/api/seestar-planner', (req, res) => {
   }
 
   // Pull every list_object that has either coordinates or an ephemeris
-  // we can compute live (same predicate as /api/planner).
+  // we can compute live (same predicate as /api/planner). Honours the
+  // shared catalog filter so this page reflects the user's selection.
+  const listSlugs = parseListSlugFilter(req.query.lists);
+  const listClause = listSlugs.length
+    ? `AND l.slug IN (${listSlugs.map(() => '?').join(',')})`
+    : '';
   const rows = db
     .prepare(
       `SELECT lo.id, lo.catalog, lo.catalog_number, lo.name, lo.object_type,
@@ -640,10 +666,11 @@ app.get('/api/seestar-planner', (req, res) => {
                        WHERE lc.list_object_id = lo.id) AS observed
          FROM list_objects lo
          JOIN lists l ON l.id = lo.list_id
-         WHERE lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
-            OR lo.ephemeris IS NOT NULL`,
+         WHERE (lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
+            OR lo.ephemeris IS NOT NULL)
+           ${listClause}`,
     )
-    .all();
+    .all(...listSlugs);
 
   function coordsAt(row, date) {
     if (row.ephemeris) {
@@ -722,6 +749,10 @@ app.get('/api/tonight', (req, res) => {
   const limit = Math.min(Number(req.query.limit) || 200, 500);
   const date = new Date();
 
+  const listSlugs = parseListSlugFilter(req.query.lists);
+  const listClause = listSlugs.length
+    ? `AND l.slug IN (${listSlugs.map(() => '?').join(',')})`
+    : '';
   const rows = db
     .prepare(
       `SELECT lo.id, lo.catalog, lo.catalog_number, lo.name, lo.object_type,
@@ -732,10 +763,11 @@ app.get('/api/tonight', (req, res) => {
                        WHERE lc.list_object_id = lo.id) AS observed
          FROM list_objects lo
          JOIN lists l ON l.id = lo.list_id
-         WHERE lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
-            OR lo.ephemeris IS NOT NULL`,
+         WHERE (lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
+            OR lo.ephemeris IS NOT NULL)
+           ${listClause}`,
     )
-    .all();
+    .all(...listSlugs);
 
   const enriched = [];
   for (const row of rows) {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -707,6 +707,42 @@ test('smoke', async (t) => {
     assert.equal(pruned.targets.length, 0);
   });
 
+  await t.test('catalog filter restricts planner / seestar / tonight to chosen lists', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    // Planner without filter sees both Messier and Caldwell entries.
+    const unfiltered = await fetchJsonAuthed(
+      `/api/planner?lat=51.5&lon=0&date=${today}&min_alt=10`,
+    );
+    const slugs = new Set(unfiltered.targets.map((t) => t.list_slug));
+    assert.ok(slugs.has('messier'));
+    assert.ok(slugs.has('caldwell'));
+    // Restrict to messier only — caldwell should disappear.
+    const messierOnly = await fetchJsonAuthed(
+      `/api/planner?lat=51.5&lon=0&date=${today}&min_alt=10&lists=messier`,
+    );
+    const m_slugs = new Set(messierOnly.targets.map((t) => t.list_slug));
+    assert.deepEqual([...m_slugs], ['messier']);
+    // Unknown slug is silently ignored; result equals no-filter.
+    const bogus = await fetchJsonAuthed(
+      `/api/planner?lat=51.5&lon=0&date=${today}&min_alt=10&lists=does-not-exist`,
+    );
+    assert.equal(bogus.targets.length, unfiltered.targets.length);
+    // Tonight honours the same filter param.
+    const tonightFiltered = await fetchJsonAuthed(
+      `/api/tonight?lat=51.5&lon=0&min_alt=0&lists=messier`,
+    );
+    const t_slugs = new Set(tonightFiltered.targets.map((t) => t.list_slug));
+    if (t_slugs.size) assert.deepEqual([...t_slugs], ['messier']);
+    // Seestar planner same.
+    const start = new Date('2026-01-15T22:00:00Z').toISOString();
+    const seestarFiltered = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&lists=messier`,
+    );
+    for (const s of seestarFiltered.slots) {
+      if (s.target) assert.equal(s.target.list_slug, 'messier');
+    }
+  });
+
   await t.test('Seestar planner returns hourly slots respecting alt window', async () => {
     // Pick a start far from sunrise at the target location so we always
     // get a non-trivial slot list. Start at 2026-01-15 22:00 UTC,


### PR DESCRIPTION
## Summary
A new "Catalogs ▾" dropdown in the toolbar of `/planner.html`, `/seestar.html`, and `/tonight.html` lets you tick which seeded lists feed the page. Selection persists in `localStorage` under a shared key, so picking Messier + Caldwell on the planner carries straight over to the Seestar planner.

### Server
- `parseListSlugFilter(req.query.lists)` helper — splits a comma-separated `lists=` param into an array of validated slugs (drops unknown ones).
- Wired into `/api/planner`, `/api/seestar-planner`, `/api/tonight`. Empty / all-checked / unknown sends nothing and the server keeps its fast no-filter path.

### Client
- New shared module `public/js/catalog-filter.js` exporting `mountCatalogFilter(container, onChange)` and `selectionToParam(slugs)`. Renders a `<details>` with one checkbox per list (fetched once from `/api/lists`). Each page imports it, mounts into a `<span id="catalog-filter">` in the toolbar, and re-runs its `load()` whenever the user toggles a checkbox.
- Summary label shows `Catalogs (3/9 ▾)` so you can tell at a glance whether the filter is narrowing.
- After mount completes, triggers one re-load if the page had already auto-loaded — keeps the first paint correct.

### Tests
+1 smoke covering all three endpoints: unfiltered planner sees Messier+Caldwell, `lists=messier` prunes Caldwell, unknown slug is silently ignored, same param shape works on `/api/tonight` and `/api/seestar-planner`.

## Test plan
- [x] `npm test` green: 31/31
- [ ] Manual: planner page → open Catalogs ▾, uncheck Caldwell → table re-renders without Caldwell rows → reload `/seestar.html` → same filter applied


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_