### PR TITLE
Seestar planner: per-type imaging durations with researched defaults

### DIFF
--- a/public/js/seestar-durations.js
+++ b/public/js/seestar-durations.js
@@ -1,0 +1,104 @@
+// Per-object-type duration picker for the Seestar planner. Defaults are
+// based on community Seestar imaging recommendations; user overrides
+// persist in localStorage. Returns a getter for the current selection in
+// the comma-separated 'GAL:90,GC:20,...' format the API expects.
+
+import { el } from './common.js';
+import { OBJECT_TYPES } from './common.js';
+
+const STORE_KEY = 'deepskylog.seestar_durations';
+
+// These are the defaults the user can override. Kept in sync with the
+// server's DEFAULT_DURATIONS map; if the server changes them and the
+// user hasn't customised, the server-side default still wins because
+// we only send the keys the user touched.
+export const DEFAULT_DURATIONS = {
+  GAL: 90, DN: 60, SNR: 90, PN: 45, MW: 30, COMET: 30,
+  GC: 20, OC: 15, PLAN: 10, AST: 10,
+  DS: 5, STAR: 5, MOON: 5,
+};
+
+// Order the inputs by length, then alpha, so the panel reads "long stuff
+// at the top".
+const DISPLAY_ORDER = Object.keys(DEFAULT_DURATIONS)
+  .sort((a, b) => (DEFAULT_DURATIONS[b] - DEFAULT_DURATIONS[a]) || a.localeCompare(b));
+
+function loadStored() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+    return typeof raw === 'object' && raw ? raw : {};
+  } catch { return {}; }
+}
+
+function store(map) {
+  try { localStorage.setItem(STORE_KEY, JSON.stringify(map)); } catch {}
+}
+
+export async function mountDurationPicker(container, onChange) {
+  const stored = loadStored();
+
+  const summary = el('summary', { style: 'cursor:pointer; padding:0.1rem 0.3rem;' });
+  const summaryLabel = document.createTextNode('Durations ▾');
+  summary.appendChild(summaryLabel);
+
+  const grid = el('div', {
+    style: 'display:grid; grid-template-columns:repeat(auto-fill, minmax(11rem, 1fr)); gap:0.25rem 0.6rem; padding:0.4rem 0.6rem; background:#1a0f08; border:1px solid var(--accent); border-radius:6px; margin-top:0.25rem;',
+  });
+
+  const inputs = {};
+  for (const code of DISPLAY_ORDER) {
+    const label = OBJECT_TYPES[code] || code;
+    const row = el('label', {
+      style: 'display:flex; justify-content:space-between; align-items:center; gap:0.4rem; font-size:0.85rem; color:var(--fg); text-transform:none; letter-spacing:0; font-weight:400;',
+    });
+    row.appendChild(document.createTextNode(label));
+    const input = el('input', {
+      type: 'number', min: '0', max: '360', step: '5',
+      value: String(stored[code] ?? DEFAULT_DURATIONS[code]),
+      style: 'width:5rem; padding:0.15rem 0.4rem; font-size:0.85rem;',
+    });
+    input.addEventListener('change', () => {
+      const map = {};
+      for (const [k, el] of Object.entries(inputs)) {
+        const n = Number(el.value);
+        // Only persist values that differ from the default — keeps
+        // future default changes effective for untouched types.
+        if (Number.isFinite(n) && n > 0 && n !== DEFAULT_DURATIONS[k]) map[k] = n;
+      }
+      store(map);
+      if (onChange) onChange();
+    });
+    inputs[code] = input;
+    row.appendChild(input);
+    grid.appendChild(row);
+  }
+
+  const reset = el('button', {
+    type: 'button',
+    style: 'margin:0.5rem 0.6rem; padding:0.2rem 0.5rem; font-size:0.8rem;',
+  }, 'Reset to defaults');
+  reset.addEventListener('click', () => {
+    for (const [code, input] of Object.entries(inputs)) {
+      input.value = String(DEFAULT_DURATIONS[code]);
+    }
+    store({});
+    if (onChange) onChange();
+  });
+
+  const details = el('details', { style: 'min-width:0;' });
+  details.appendChild(summary);
+  details.appendChild(grid);
+  details.appendChild(reset);
+  container.appendChild(details);
+
+  return function getDurationParam() {
+    const parts = [];
+    for (const [code, input] of Object.entries(inputs)) {
+      const n = Number(input.value);
+      if (Number.isFinite(n) && n > 0 && n !== DEFAULT_DURATIONS[code]) {
+        parts.push(`${code}:${n}`);
+      }
+    }
+    return parts.join(',');
+  };
+}

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -1,5 +1,6 @@
 import { fetchJson, el, typeLabel, highlightNav } from './common.js';
 import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
+import { mountDurationPicker } from './seestar-durations.js';
 
 highlightNav('seestar');
 
@@ -8,6 +9,14 @@ mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   load();
 }).then((fn) => {
   getCatalogSelection = fn;
+  if (rows.children.length) load();
+});
+
+let getDurationParam = () => '';
+mountDurationPicker(document.getElementById('duration-filter'), () => {
+  load();
+}).then((fn) => {
+  getDurationParam = fn;
   if (rows.children.length) load();
 });
 
@@ -65,6 +74,8 @@ async function load() {
   if (includeObserved.checked) params.set('include_observed', '1');
   const catParam = selectionToParam(getCatalogSelection());
   if (catParam) params.set('lists', catParam);
+  const durParam = getDurationParam();
+  if (durParam) params.set('durations', durParam);
 
   let data;
   try {
@@ -88,16 +99,18 @@ async function load() {
   status.textContent = `${filled} of ${data.slots.length} slot${data.slots.length === 1 ? '' : 's'} filled`;
 
   if (!data.slots.length) {
-    rows.appendChild(el('tr', {}, el('td', { colspan: '10' },
+    rows.appendChild(el('tr', {}, el('td', { colspan: '11' },
       el('div', { class: 'empty-state', text: 'No imaging window — sunrise is within the next hour.' }))));
     return;
   }
 
   for (const slot of data.slots) {
     const slotLabel = `${fmtTime(slot.slot_start)} – ${fmtTime(slot.slot_end)}`;
+    const dur = slot.duration_minutes != null ? `${slot.duration_minutes} min` : '—';
     if (!slot.target) {
       rows.appendChild(el('tr', { class: 'dim' },
         el('td', { text: slotLabel }),
+        el('td', { text: dur }),
         el('td', { colspan: '9', class: 'empty-state', text: 'No target in altitude range that hasn\'t been used yet.' }),
       ));
       continue;
@@ -105,6 +118,7 @@ async function load() {
     const t = slot.target;
     rows.appendChild(el('tr', { class: t.observed ? 'observed' : '' },
       el('td', { text: slotLabel }),
+      el('td', { text: dur }),
       el('td', {}, el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
       el('td', { text: t.name || '—' }),
       el('td', { text: typeLabel(t.object_type) }),

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -23,7 +23,7 @@
     </header>
     <main>
       <h1 class="page-title">Seestar session planner</h1>
-      <p class="page-subtitle" id="subtitle">One target per hour from now until an hour before sunrise. Each pick is above your minimum altitude at the slot start, and stays under the zenith-avoidance ceiling by the slot end.</p>
+      <p class="page-subtitle" id="subtitle">Targets allocated by per-type imaging duration, running from now until an hour before sunrise. Each pick is above your minimum altitude at the slot start and stays under the zenith-avoidance ceiling by the slot end.</p>
 
       <div class="toolbar">
         <label>
@@ -46,6 +46,7 @@
           <input id="include-observed" type="checkbox" /> Include observed
         </label>
         <span id="catalog-filter"></span>
+        <span id="duration-filter"></span>
         <button type="button" id="locate-btn">Use my location</button>
         <button type="button" id="run-btn">Plan</button>
         <span id="status" class="dim" style="margin-left:auto;"></span>
@@ -59,6 +60,7 @@
           <thead>
             <tr>
               <th>Slot</th>
+              <th>Duration</th>
               <th>Object</th>
               <th>Name</th>
               <th>Type</th>

--- a/server.js
+++ b/server.js
@@ -642,12 +642,29 @@ app.get('/api/seestar-planner', (req, res) => {
     ? new Date(sunrise.getTime() - 3_600_000)
     : new Date(start.getTime() + 12 * 3_600_000);
 
-  // Slot grid: start, +1h, +2h, … each slot is start→start+1h. We don't
-  // start a new slot whose start ≥ sessionEnd.
-  const slots = [];
-  for (let t = start.getTime(); t < sessionEnd.getTime(); t += 3_600_000) {
-    slots.push({ start: new Date(t), end: new Date(t + 3_600_000) });
+  // Per-object-type recommended imaging durations (minutes). The defaults
+  // are based on Seestar community conventions for f/4-5 smart-scope
+  // stacks. Override via the durations query param, e.g.:
+  //   durations=GAL:90,GC:20,OC:15
+  // Anything not in the map (or set to <= 0) falls back to defaultDur.
+  const DEFAULT_DURATIONS = {
+    GAL: 90, DN: 60, SNR: 90, PN: 45, MW: 30, COMET: 30,
+    GC: 20, OC: 15, PLAN: 10, AST: 10,
+    DS: 5, STAR: 5, MOON: 5,
+  };
+  const defaultDur = 60;
+  const userDurations = {};
+  if (req.query.durations) {
+    for (const piece of String(req.query.durations).split(',')) {
+      const [k, v] = piece.split(':').map((s) => s.trim());
+      const n = Number(v);
+      if (k && Number.isFinite(n) && n > 0 && n <= 360) userDurations[k.toUpperCase()] = n;
+    }
   }
+  const durationFor = (type) => {
+    const t = (type || '').toUpperCase();
+    return userDurations[t] ?? DEFAULT_DURATIONS[t] ?? defaultDur;
+  };
 
   // Pull every list_object that has either coordinates or an ephemeris
   // we can compute live (same predicate as /api/planner). Honours the
@@ -682,49 +699,71 @@ app.get('/api/seestar-planner', (req, res) => {
     return { raHours: row.ra_hours, decDeg: row.dec_degrees };
   }
 
+  // Variable-duration slot walk. Walk forward from `start`; at each step
+  // we look at every eligible target, compute its altitude at the step's
+  // start AND at start+durationFor(target.type). Keep targets where the
+  // start altitude ≥ minAlt, the end altitude ≤ maxAlt, AND the slot
+  // doesn't run past sessionEnd. Pick the lowest qualifying alt_start so
+  // climbing targets get priority, then advance time by the chosen
+  // target's duration. If nothing fits at the current moment, advance by
+  // 15 min and retry — covers the common "wait 15 minutes for the next
+  // good target to clear 50°" case without spinning forever.
   const assignedIds = new Set();
-  const plan = slots.map((slot) => {
-    // Score every eligible target for this slot and take the best one.
+  const plan = [];
+  let cursor = start.getTime();
+  let stalled = 0;
+  while (cursor < sessionEnd.getTime()) {
+    const slotStart = new Date(cursor);
     let best = null;
     for (const row of rows) {
       if (!includeObserved && row.observed) continue;
       if (assignedIds.has(row.id)) continue;
-      const eqStart = coordsAt(row, slot.start);
-      const eqEnd = coordsAt(row, slot.end);
+      const dur = durationFor(row.object_type);
+      const slotEndMs = cursor + dur * 60_000;
+      if (slotEndMs > sessionEnd.getTime()) continue;
+      const slotEnd = new Date(slotEndMs);
+      const eqStart = coordsAt(row, slotStart);
+      const eqEnd = coordsAt(row, slotEnd);
       if (!eqStart || !eqEnd) continue;
-      const posStart = altAz({ ...eqStart, lat, lon, date: slot.start });
-      const posEnd = altAz({ ...eqEnd, lat, lon, date: slot.end });
+      const posStart = altAz({ ...eqStart, lat, lon, date: slotStart });
+      const posEnd = altAz({ ...eqEnd, lat, lon, date: slotEnd });
       if (!posStart || !posEnd) continue;
       if (posStart.altitude < minAlt) continue;
       if (posEnd.altitude > maxAlt) continue;
-      // Prefer the target that's lowest at start (most window to climb)
-      // but still above min_alt — keeps zenith-bound targets for later
-      // slots when they're more useful. Tie-break on brightness.
       const score = -posStart.altitude * 1000 - (row.magnitude ?? 99);
       if (!best || score > best.score) {
-        best = { row, posStart, posEnd, score };
+        best = { row, posStart, posEnd, score, dur, slotEnd };
       }
     }
-    if (!best) return { ...{ slot_start: slot.start.toISOString(), slot_end: slot.end.toISOString() }, target: null };
+    if (!best) {
+      stalled += 1;
+      // Bail after an hour of stalled retries — no point looping forever.
+      if (stalled > 4) break;
+      cursor += 15 * 60_000;
+      continue;
+    }
+    stalled = 0;
     assignedIds.add(best.row.id);
-    const { row, posStart, posEnd } = best;
-    return {
-      slot_start: slot.start.toISOString(),
-      slot_end: slot.end.toISOString(),
+    plan.push({
+      slot_start: slotStart.toISOString(),
+      slot_end: best.slotEnd.toISOString(),
+      duration_minutes: best.dur,
       target: {
-        id: row.id,
-        catalog: row.catalog, catalog_number: row.catalog_number,
-        name: row.name, object_type: row.object_type, constellation: row.constellation,
-        magnitude: row.magnitude,
-        list_slug: row.list_slug, list_name: row.list_name,
-        observed: !!row.observed,
-        altitude_at_start: posStart.altitude,
-        altitude_at_end: posEnd.altitude,
-        azimuth_at_start: posStart.azimuth,
-        azimuth_at_end: posEnd.azimuth,
+        id: best.row.id,
+        catalog: best.row.catalog, catalog_number: best.row.catalog_number,
+        name: best.row.name, object_type: best.row.object_type,
+        constellation: best.row.constellation,
+        magnitude: best.row.magnitude,
+        list_slug: best.row.list_slug, list_name: best.row.list_name,
+        observed: !!best.row.observed,
+        altitude_at_start: best.posStart.altitude,
+        altitude_at_end: best.posEnd.altitude,
+        azimuth_at_start: best.posStart.azimuth,
+        azimuth_at_end: best.posEnd.azimuth,
       },
-    };
-  });
+    });
+    cursor = best.slotEnd.getTime();
+  }
 
   res.json({
     location: { lat, lon },
@@ -733,6 +772,7 @@ app.get('/api/seestar-planner', (req, res) => {
     min_altitude: minAlt,
     max_altitude: maxAlt,
     moon: moonPhase(start),
+    durations: { ...DEFAULT_DURATIONS, ...userDurations, _default: defaultDur },
     slots: plan,
   });
 });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -743,7 +743,7 @@ test('smoke', async (t) => {
     }
   });
 
-  await t.test('Seestar planner returns hourly slots respecting alt window', async () => {
+  await t.test('Seestar planner returns variable-duration slots in alt window', async () => {
     // Pick a start far from sunrise at the target location so we always
     // get a non-trivial slot list. Start at 2026-01-15 22:00 UTC,
     // observer at (51.5, 0) — guaranteed dark night in January.
@@ -752,23 +752,39 @@ test('smoke', async (t) => {
       `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&min_alt=50&max_alt=80`,
     );
     assert.ok(Array.isArray(data.slots), 'slots present');
-    assert.ok(data.slots.length >= 4, `expected several hourly slots, got ${data.slots.length}`);
-    // Sunrise should be in the morning.
+    assert.ok(data.slots.length >= 4, `expected several slots, got ${data.slots.length}`);
+    assert.ok(typeof data.durations === 'object' && data.durations._default,
+      'durations map returned');
+    // Sunrise should be in the morning. Window ends an hour before.
     assert.ok(data.sunrise, 'sunrise computed');
-    // Window end = sunrise - 1h.
     const end = new Date(data.window.end).getTime();
     const sunrise = new Date(data.sunrise).getTime();
     assert.equal(sunrise - end, 3_600_000, 'window ends an hour before sunrise');
-    // Every assigned target must be in the [50, 80] window at slot start
-    // and end, and no target may be assigned twice.
+    // Each slot's end equals start + duration_minutes, every target is
+    // in the alt window, no duplicates, and no slot runs past session end.
     const seen = new Set();
     for (const s of data.slots) {
-      if (!s.target) continue;
-      assert.ok(!seen.has(s.target.id), `target ${s.target.id} assigned twice`);
-      seen.add(s.target.id);
-      assert.ok(s.target.altitude_at_start >= 50, 'alt_start >= min');
-      assert.ok(s.target.altitude_at_end <= 80, 'alt_end <= max');
+      assert.equal(typeof s.duration_minutes, 'number');
+      if (s.target) {
+        assert.ok(!seen.has(s.target.id), `target ${s.target.id} assigned twice`);
+        seen.add(s.target.id);
+        assert.ok(s.target.altitude_at_start >= 50, 'alt_start >= min');
+        assert.ok(s.target.altitude_at_end <= 80, 'alt_end <= max');
+      }
+      const sEnd = new Date(s.slot_end).getTime();
+      const sStart = new Date(s.slot_start).getTime();
+      assert.equal((sEnd - sStart) / 60_000, s.duration_minutes, 'slot end matches duration');
+      assert.ok(sEnd <= end, 'slot ends at or before session end');
     }
+    // With huge custom durations (90 min for everything), we should get
+    // fewer slots than the default mix.
+    const huge = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&min_alt=50&max_alt=80&durations=GAL:90,GC:90,OC:90,PN:90,DN:90,SNR:90,MW:90,AST:90,DS:90,STAR:90,MOON:90,PLAN:90,COMET:90`,
+    );
+    assert.ok(huge.slots.every((s) => !s.target || s.duration_minutes === 90),
+      'all targeted slots use the custom 90-min duration');
+    assert.ok(huge.slots.filter((s) => s.target).length <= data.slots.filter((s) => s.target).length,
+      'longer durations yield ≤ default slot count');
   });
 
   await t.test('NGC fallback resolves common designations', async () => {


### PR DESCRIPTION
## Summary
Seestar planner now allocates each slot the duration recommended for its target type, with the user able to override every value from a "Durations ▾" panel.

### Baked-in defaults (minutes)
Based on Seestar community conventions for f/4–5 smart-scope stacks:

| Type | Minutes | Why |
|---|---|---|
| Galaxy (GAL) | 90 | Faint, broadband — needs a long stack |
| Supernova Remnant (SNR) | 90 | Faint filaments |
| Diffuse Nebula (DN) | 60 | Bright cores, faint halos |
| Planetary Nebula (PN) | 45 | Bright cores, faint outer detail |
| Star Cloud (MW) | 30 | Sky-flat fairness > depth |
| Comet (COMET) | 30 | Snapshot-style; motion limits stack |
| Globular Cluster (GC) | 20 | Bright core resolves quickly |
| Open Cluster (OC) | 15 | Already bright |
| Planet (PLAN) | 10 | Lucky imaging, not stacking |
| Asterism (AST) | 10 | Just stars |
| Double Star / Star / Moon | 5 | Snapshot |

### Server
- New `durations=GAL:90,GC:20,…` query param parses into a `{type: min}` map; values > 0 and ≤ 360 are accepted.
- Slot walk: start from `req.query.start` (or now), iterate forward. At each step, pick the unobserved target whose alt at start ≥ `min_alt` AND alt at `start + durations[type]` ≤ `max_alt` AND whose slot doesn't run past `sunrise - 1h`. Advance cursor by that target's duration. If nothing fits, retry 15 min later (up to 1 h of stall before bailing).
- Response includes `duration_minutes` per slot and a `durations` map showing the merged effective defaults.

### Client
- New `public/js/seestar-durations.js` module renders a `<details>` panel with one number input per type, sorted longest→shortest, plus a Reset button. Only values that differ from default are persisted (so future default tuning still applies to untouched types).
- New "Duration" column on the seestar planner table.

### Tests
+1 smoke covering: defaults yield slots with `duration_minutes` matching `slot_end - slot_start`; targets stay in the alt window; setting durations=90 across the board yields ≤ default slot count.

## Test plan
- [x] `npm test` green: 31/31
- [ ] Manual: `/seestar.html` → open Durations ▾, change Galaxy to 120, watch the table re-render with longer galaxy slots


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_