### PR TITLE
Type filter shared across Planner, Seestar planner, Tonight

### DIFF
--- a/public/js/planner.js
+++ b/public/js/planner.js
@@ -1,5 +1,6 @@
 import { fetchJson, el, typeLabel, highlightNav } from './common.js';
 import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
+import { mountTypeFilter, typesToParam } from './type-filter.js';
 
 highlightNav('planner');
 
@@ -14,6 +15,7 @@ mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   // now that we know which catalogs the user wants.
   if (rows.children.length) load();
 });
+const getTypeSelection = mountTypeFilter(document.getElementById('type-filter'), () => load());
 
 const dateInput = document.getElementById('date-input');
 const timeInput = document.getElementById('time-input');
@@ -126,6 +128,8 @@ async function load() {
   if (minMoonSep > 0) params.set('min_moon_sep', String(minMoonSep));
   const catParam = selectionToParam(getCatalogSelection());
   if (catParam) params.set('lists', catParam);
+  const typeParam = typesToParam(getTypeSelection());
+  if (typeParam) params.set('types', typeParam);
   if (time) {
     // Combine date+time as local — the resulting Date is correct UTC instant.
     const start = new Date(`${date}T${time}`);

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -1,5 +1,6 @@
 import { fetchJson, el, typeLabel, highlightNav } from './common.js';
 import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
+import { mountTypeFilter, typesToParam } from './type-filter.js';
 import { mountDurationPicker } from './seestar-durations.js';
 
 highlightNav('seestar');
@@ -11,6 +12,7 @@ mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   getCatalogSelection = fn;
   if (rows.children.length) load();
 });
+const getTypeSelection = mountTypeFilter(document.getElementById('type-filter'), () => load());
 
 let getDurationParam = () => '';
 mountDurationPicker(document.getElementById('duration-filter'), () => {
@@ -74,6 +76,8 @@ async function load() {
   if (includeObserved.checked) params.set('include_observed', '1');
   const catParam = selectionToParam(getCatalogSelection());
   if (catParam) params.set('lists', catParam);
+  const typeParam = typesToParam(getTypeSelection());
+  if (typeParam) params.set('types', typeParam);
   const durParam = getDurationParam();
   if (durParam) params.set('durations', durParam);
 

--- a/public/js/tonight.js
+++ b/public/js/tonight.js
@@ -1,5 +1,6 @@
 import { fetchJson, el, typeLabel, highlightNav } from './common.js';
 import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
+import { mountTypeFilter, typesToParam } from './type-filter.js';
 
 highlightNav('tonight');
 
@@ -10,6 +11,7 @@ mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   getCatalogSelection = fn;
   if (rows.children.length) load();
 });
+const getTypeSelection = mountTypeFilter(document.getElementById('type-filter'), () => load());
 
 const latInput = document.getElementById('lat-input');
 const lonInput = document.getElementById('lon-input');
@@ -59,6 +61,8 @@ async function load() {
   if (includeObserved.checked) params.set('include_observed', '1');
   const catParam = selectionToParam(getCatalogSelection());
   if (catParam) params.set('lists', catParam);
+  const typeParam = typesToParam(getTypeSelection());
+  if (typeParam) params.set('types', typeParam);
 
   let data;
   try {

--- a/public/js/type-filter.js
+++ b/public/js/type-filter.js
@@ -1,0 +1,80 @@
+// Shared object-type filter used by /planner.html, /seestar.html and
+// /tonight.html — companion to catalog-filter.js. Lets the user
+// uncheck e.g. "Open Cluster" to drop those types from the plans.
+// Selection persists in localStorage so it carries across pages.
+
+import { el, OBJECT_TYPES } from './common.js';
+
+const STORE_KEY = 'deepskylog.type_filter';
+
+// Default order — observers usually scan past brighter / smaller types
+// first when pruning, so keep deep-sky stuff up top.
+const DISPLAY_ORDER = [
+  'GAL', 'DN', 'PN', 'SNR', 'GC', 'OC', 'MW', 'AST',
+  'STAR', 'DS', 'COMET', 'PLAN', 'MOON',
+];
+
+function loadStored() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORE_KEY) || 'null');
+    return Array.isArray(raw) ? raw : null;
+  } catch { return null; }
+}
+
+function storeSelection(types) {
+  try { localStorage.setItem(STORE_KEY, JSON.stringify(types)); } catch {}
+}
+
+export function mountTypeFilter(container, onChange) {
+  const all = DISPLAY_ORDER.filter((t) => OBJECT_TYPES[t]);
+  const stored = loadStored();
+  const startSelection = stored == null ? [...all]
+    : stored.filter((t) => all.includes(t));
+
+  const summary = el('summary', { style: 'cursor:pointer; padding:0.1rem 0.3rem;' });
+  const summaryLabel = document.createTextNode('');
+  summary.appendChild(summaryLabel);
+
+  const grid = el('div', {
+    style: 'display:grid; grid-template-columns:repeat(auto-fill, minmax(11rem, 1fr)); gap:0.2rem 0.6rem; padding:0.4rem 0.6rem; background:#1a0f08; border:1px solid var(--accent); border-radius:6px; margin-top:0.25rem;',
+  });
+
+  const checkboxes = [];
+  for (const code of all) {
+    const cb = el('input', { type: 'checkbox', value: code });
+    if (startSelection.includes(code)) cb.checked = true;
+    cb.addEventListener('change', () => {
+      const selection = checkboxes.filter((c) => c.checked).map((c) => c.value);
+      storeSelection(selection);
+      updateSummary();
+      if (onChange) onChange();
+    });
+    checkboxes.push(cb);
+    const label = el('label', { style: 'display:flex; gap:0.4rem; align-items:center; font-size:0.85rem; color:var(--fg); text-transform:none; letter-spacing:0; font-weight:400;' });
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(` ${OBJECT_TYPES[code]}`));
+    grid.appendChild(label);
+  }
+
+  function updateSummary() {
+    const n = checkboxes.filter((c) => c.checked).length;
+    const total = checkboxes.length;
+    summaryLabel.data = `Types (${n === total || n === 0 ? 'all' : `${n}/${total}`}) ▾`;
+  }
+  updateSummary();
+
+  const details = el('details', { style: 'min-width:0;' });
+  details.appendChild(summary);
+  details.appendChild(grid);
+  container.appendChild(details);
+
+  return function getSelection() {
+    const selected = checkboxes.filter((c) => c.checked).map((c) => c.value);
+    if (selected.length === 0 || selected.length === checkboxes.length) return [];
+    return selected;
+  };
+}
+
+export function typesToParam(types) {
+  return types.length ? types.join(',') : '';
+}

--- a/public/planner.html
+++ b/public/planner.html
@@ -54,6 +54,7 @@
           <input id="include-observed" type="checkbox" /> Include observed
         </label>
         <span id="catalog-filter"></span>
+        <span id="type-filter"></span>
         <button type="button" id="locate-btn">Use my location</button>
         <button type="button" id="run-btn">Plan</button>
         <span id="status" class="dim" style="margin-left:auto;"></span>

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -46,6 +46,7 @@
           <input id="include-observed" type="checkbox" /> Include observed
         </label>
         <span id="catalog-filter"></span>
+        <span id="type-filter"></span>
         <span id="duration-filter"></span>
         <button type="button" id="locate-btn">Use my location</button>
         <button type="button" id="run-btn">Plan</button>

--- a/public/tonight.html
+++ b/public/tonight.html
@@ -42,6 +42,7 @@
           <input id="include-observed" type="checkbox" /> Include observed
         </label>
         <span id="catalog-filter"></span>
+        <span id="type-filter"></span>
         <button type="button" id="locate-btn">Use my location</button>
         <button type="button" id="refresh-btn">Refresh</button>
         <span id="status" class="dim" style="margin-left:auto;"></span>

--- a/server.js
+++ b/server.js
@@ -412,6 +412,22 @@ function parseListSlugFilter(raw) {
   return wanted.filter((s) => valid.has(s));
 }
 
+// Parse a comma-separated `types=` query param into an array of allowed
+// object type codes (uppercase, deduped). Empty = no filter. Same shape
+// as parseListSlugFilter so the callers stay symmetric.
+const VALID_OBJECT_TYPES = new Set([
+  'GC','OC','PN','SNR','DN','GAL','MW','AST','DS','STAR','MOON','PLAN','COMET',
+]);
+function parseTypeFilter(raw) {
+  if (!raw) return [];
+  const wanted = String(raw)
+    .split(',')
+    .map((s) => s.trim().toUpperCase())
+    .filter(Boolean);
+  if (!wanted.length) return [];
+  return [...new Set(wanted.filter((t) => VALID_OBJECT_TYPES.has(t)))];
+}
+
 app.get('/api/planner', (req, res) => {
   const lat = Number(req.query.lat);
   const lon = Number(req.query.lon);
@@ -454,6 +470,14 @@ app.get('/api/planner', (req, res) => {
   const listClause = listSlugs.length
     ? `AND l.slug IN (${listSlugs.map(() => '?').join(',')})`
     : '';
+  // Optional type filter — drop any list_object whose type isn't ticked.
+  // NULL types stay in: they're free-form / unclassified rows the user
+  // would otherwise lose. The catch-all behaviour matches the catalog
+  // filter, where an unknown slug just gets ignored.
+  const typeAllow = parseTypeFilter(req.query.types);
+  const typeClause = typeAllow.length
+    ? `AND (lo.object_type IS NULL OR lo.object_type IN (${typeAllow.map(() => '?').join(',')}))`
+    : '';
 
   const rows = db
     .prepare(
@@ -467,9 +491,10 @@ app.get('/api/planner', (req, res) => {
          JOIN lists l ON l.id = lo.list_id
          WHERE (lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
             OR lo.ephemeris IS NOT NULL)
-           ${listClause}`,
+           ${listClause}
+           ${typeClause}`,
     )
-    .all(...listSlugs);
+    .all(...listSlugs, ...typeAllow);
 
   // Pre-compute sun and moon position+altitude across the window. Used for
   // both target-vs-moon separation and the twilight/moon-up bands surfaced
@@ -668,10 +693,14 @@ app.get('/api/seestar-planner', (req, res) => {
 
   // Pull every list_object that has either coordinates or an ephemeris
   // we can compute live (same predicate as /api/planner). Honours the
-  // shared catalog filter so this page reflects the user's selection.
+  // shared catalog + type filters so this page reflects the user's choices.
   const listSlugs = parseListSlugFilter(req.query.lists);
   const listClause = listSlugs.length
     ? `AND l.slug IN (${listSlugs.map(() => '?').join(',')})`
+    : '';
+  const typeAllow = parseTypeFilter(req.query.types);
+  const typeClause = typeAllow.length
+    ? `AND (lo.object_type IS NULL OR lo.object_type IN (${typeAllow.map(() => '?').join(',')}))`
     : '';
   const rows = db
     .prepare(
@@ -685,9 +714,10 @@ app.get('/api/seestar-planner', (req, res) => {
          JOIN lists l ON l.id = lo.list_id
          WHERE (lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
             OR lo.ephemeris IS NOT NULL)
-           ${listClause}`,
+           ${listClause}
+           ${typeClause}`,
     )
-    .all(...listSlugs);
+    .all(...listSlugs, ...typeAllow);
 
   function coordsAt(row, date) {
     if (row.ephemeris) {
@@ -793,6 +823,10 @@ app.get('/api/tonight', (req, res) => {
   const listClause = listSlugs.length
     ? `AND l.slug IN (${listSlugs.map(() => '?').join(',')})`
     : '';
+  const typeAllow = parseTypeFilter(req.query.types);
+  const typeClause = typeAllow.length
+    ? `AND (lo.object_type IS NULL OR lo.object_type IN (${typeAllow.map(() => '?').join(',')}))`
+    : '';
   const rows = db
     .prepare(
       `SELECT lo.id, lo.catalog, lo.catalog_number, lo.name, lo.object_type,
@@ -805,9 +839,10 @@ app.get('/api/tonight', (req, res) => {
          JOIN lists l ON l.id = lo.list_id
          WHERE (lo.ra_hours IS NOT NULL OR lo.dec_degrees IS NOT NULL
             OR lo.ephemeris IS NOT NULL)
-           ${listClause}`,
+           ${listClause}
+           ${typeClause}`,
     )
-    .all(...listSlugs);
+    .all(...listSlugs, ...typeAllow);
 
   const enriched = [];
   for (const row of rows) {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -743,6 +743,43 @@ test('smoke', async (t) => {
     }
   });
 
+  await t.test('object-type filter prunes types from planner / seestar / tonight', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    // Planner with only galaxies — every assigned target must be a GAL
+    // (or have a null type via the COALESCE fallback path, but seeded
+    // rows always have a type).
+    const galOnly = await fetchJsonAuthed(
+      `/api/planner?lat=51.5&lon=0&date=${today}&min_alt=10&types=GAL`,
+    );
+    assert.ok(galOnly.targets.length > 0, 'still finds galaxies');
+    for (const tgt of galOnly.targets) {
+      assert.equal(tgt.object_type, 'GAL', `non-GAL slipped through: ${tgt.object_type}`);
+    }
+    // Excluding all sensible deep-sky types should empty the planner.
+    const planetsOnly = await fetchJsonAuthed(
+      `/api/planner?lat=51.5&lon=0&date=${today}&min_alt=0&types=COMET`,
+    );
+    for (const tgt of planetsOnly.targets) {
+      assert.equal(tgt.object_type, 'COMET');
+    }
+    // Seestar planner honours the same filter — no GC targets when GC
+    // isn't ticked.
+    const start = new Date('2026-01-15T22:00:00Z').toISOString();
+    const seestarNoGC = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&types=GAL,DN,PN,SNR,OC,MW,AST,STAR,DS,COMET,PLAN,MOON`,
+    );
+    for (const s of seestarNoGC.slots) {
+      if (s.target) assert.notEqual(s.target.object_type, 'GC');
+    }
+    // Tonight honours it too.
+    const tonightGalOnly = await fetchJsonAuthed(
+      `/api/tonight?lat=51.5&lon=0&min_alt=0&types=GAL`,
+    );
+    for (const t of tonightGalOnly.targets) {
+      assert.equal(t.object_type, 'GAL');
+    }
+  });
+
   await t.test('Seestar planner returns variable-duration slots in alt window', async () => {
     // Pick a start far from sunrise at the target location so we always
     // get a non-trivial slot list. Start at 2026-01-15 22:00 UTC,


### PR DESCRIPTION
## Summary
Companion to the catalog filter — a new "Types ▾" dropdown next to "Catalogs ▾" lets you uncheck object types (globular clusters, open clusters, planetaries, …) to drop them from the plans. Selection persists in `localStorage` so it carries across `/planner.html`, `/seestar.html`, `/tonight.html`.

### Server
- `parseTypeFilter(req.query.types)` helper — comma-separated codes from the canonical OBJECT_TYPES vocabulary; unknown codes silently dropped.
- Wired into `/api/planner`, `/api/seestar-planner`, `/api/tonight` with the same SQL pattern as `parseListSlugFilter`. NULL types stay in (free-form / unclassified rows aren't lost).

### Client
- New shared module `public/js/type-filter.js` exporting `mountTypeFilter(container, onChange)` + `typesToParam(slugs)`. Built from `OBJECT_TYPES` in `common.js` so it stays in sync with everything else. Summary reads `Types (10/13 ▾)`.
- Each of the three pages imports it, mounts into a `<span id="type-filter">`, and re-runs `load()` on change.

### Tests
+1 smoke covering all three endpoints: `types=GAL` prunes to galaxies only on planner; seestar planner with everything except GC checked produces no GC slots; tonight respects the same param.

## Test plan
- [x] `npm test` green: 32/32
- [ ] Manual: Seestar planner → Types ▾ → uncheck Open Cluster + Globular Cluster → re-plan, no OC/GC slots


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_