### PR TITLE
Toolbar: cap corner radius so wrapped rows don't clip content

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -303,9 +303,13 @@ tbody tr.observed:hover { background: rgba(153, 204, 153, 0.2); }
   gap: 0.7rem;
   align-items: center;
   margin-bottom: 1rem;
-  padding: 0.75rem 1rem;
+  /* Extra left/right padding keeps content out of the corner curve when
+     the toolbar wraps to multiple rows; the radius is capped at 1.75rem
+     instead of var(--pill) (~999px) so it doesn't bite into "LATITUDE"
+     on row 1 or the trailing status text on row 2. */
+  padding: 0.75rem 1.5rem;
   background: var(--accent-2);
-  border-radius: var(--pill) 12px var(--pill) 12px;
+  border-radius: 1.75rem 12px 1.75rem 12px;
   color: #000;
 }
 


### PR DESCRIPTION
## Summary
The LCARS toolbar used `border-radius: var(--pill) 12px var(--pill) 12px`. `--pill` is `999px`, so on a single row that draws the intended pill shape, but on a wrapped toolbar (the planner / Seestar toolbar now has enough controls to wrap) the half-height curve bit into "LATITUDE" on row 1 and the trailing status text on row 2.

Capping the radius at `1.75rem` — still a visible LCARS curve, small enough not to overlap content — and bumping horizontal padding to `1.5rem` so the leftmost label has breathing room.

## Test plan
- [x] `npm test` green: 32/32
- [ ] Manual: open `/seestar.html`, confirm "LATITUDE" and trailing status text aren't clipped by the rounded corners.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_