### PR TITLE
Bugs #46/47/48/50/52: cache-bust, broken admin link, NaN clamp, NGC aliases, write rate-limit

### DIFF
--- a/admin/observations.js
+++ b/admin/observations.js
@@ -90,7 +90,10 @@ function renderRows() {
         })
       : el('span', { class: 'thumb-chip empty', text: '—' });
 
-    const objCell = (o.object_id || (o.catalog && o.catalog_number))
+    // Only build the link when we actually have an object_id; the old
+    // condition also fired for free-form catalog rows (e.g. typed
+    // 'C/2023 A3') and produced /admin/object.html?id=undefined.
+    const objCell = o.object_id
       ? el('a', {
           href: `/admin/object.html?id=${encodeURIComponent(o.object_id)}`,
           text: objectLabel(o),

--- a/backlog.md
+++ b/backlog.md
@@ -207,14 +207,14 @@ expansions. Listed roughly by user-visible impact, not effort.
 
 ### Should fix soon
 
-46. **No cache-busting on `/js/*.js`.** Static page `<script type="module"
+46. ✅ **No cache-busting on `/js/*.js`.** Static page `<script type="module"
     src="/js/foo.js">` URLs never change, so when a Docker build ships
     new JS the browser keeps serving the old one until the user does a
     hard refresh. Several "it's still broken" reports in this session
     traced back to this. Fix: stamp `?v=<GIT_SHA>` into the script tags
     server-side at request time, using the `GIT_SHA` build-arg the
     docker workflow already passes.
-47. **`/admin/object.html?id=undefined` link generated for free-form
+47. ✅ **`/admin/object.html?id=undefined` link generated for free-form
     observations.** `admin/observations.js` lines ~93–98 wrap the
     object cell in an anchor whenever `o.object_id || (o.catalog &&
     o.catalog_number)` is truthy, but the href uses `o.object_id`
@@ -222,7 +222,7 @@ expansions. Listed roughly by user-visible impact, not effort.
     `C/2023 A3`) renders `<a href="/admin/object.html?id=undefined">`.
     Either drop the anchor when `o.object_id` is null, or send the
     user to `/admin/observations.html#row-N` instead.
-48. **`clamp()` returns NaN for unparseable numbers.** The helper at
+48. ✅ **`clamp()` returns NaN for unparseable numbers.** The helper at
     line ~2031 reads `Math.max(lo, Math.min(hi, Number(v)))` — if
     `Number(v)` is NaN, the math propagates NaN and we hand it to
     `better-sqlite3`. Hard to hit through the UI (clients always send
@@ -236,7 +236,7 @@ expansions. Listed roughly by user-visible impact, not effort.
     plan early instead of skipping over a dry hour and resuming when
     something rises again. Better: keep stepping forward until
     `sessionEnd`, only break on natural end.
-50. **OpenNGC alias collisions.** `lib/ngc.js` indexes both primary
+50. ✅ **OpenNGC alias collisions.** `lib/ngc.js` indexes both primary
     name and every Common-name alias in a single `Map`, so when two
     catalog entries share a common name (e.g. "Veil Nebula" maps to
     multiple NGCs) only the first one wins. Symptom: typing a popular
@@ -252,7 +252,7 @@ expansions. Listed roughly by user-visible impact, not effort.
     origin via `fetch(..., {credentials: 'include'})`. Fix: require
     a same-origin header, a CSRF token, or switch admin to a session
     cookie with `SameSite=Strict`.
-52. **No rate-limit on successful admin writes.** The per-IP sliding
+52. ✅ **No rate-limit on successful admin writes.** The per-IP sliding
     window in `basicAuth` only counts failures; once authed, a bot
     with the password can spam observations. Add a token bucket on
     write endpoints to make abuse noisy.

--- a/lib/ngc.js
+++ b/lib/ngc.js
@@ -9,24 +9,33 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-let CACHE = null;          // { byKey: Map, all: [] }
+let CACHE = null;          // { primary: Map, aliases: Map<key, row[]>, all: [] }
 
 function load() {
   if (CACHE) return CACHE;
   const raw = fs.readFileSync(path.join(__dirname, '..', 'db', 'seed', 'ngc.json'), 'utf8');
   const all = JSON.parse(raw);
-  const byKey = new Map();
+  // primary  : normalised primary name  → row  (1:1)
+  // aliases  : normalised common name   → row[] (1:N, multiple rows may share
+  //            an alias like 'Veil Nebula'; we keep them all so callers can
+  //            surface a 'did you mean…?' picker).
+  const primary = new Map();
+  const aliases = new Map();
   for (const row of all) {
     const [name, , , , , , common] = row;
-    byKey.set(normalise(name), row);
-    // Also index common names (M42, Orion Nebula, etc.) so lookup works
-    // for the names users actually type.
+    primary.set(normalise(name), row);
     for (const alias of String(common || '').split(',')) {
       const k = normalise(alias);
-      if (k && !byKey.has(k)) byKey.set(k, row);
+      if (!k) continue;
+      // Don't shadow a primary key with a common-name alias.
+      if (primary.has(k)) continue;
+      const arr = aliases.get(k);
+      if (arr) {
+        if (!arr.includes(row)) arr.push(row);
+      } else aliases.set(k, [row]);
     }
   }
-  CACHE = { byKey, all };
+  CACHE = { primary, aliases, all };
   return CACHE;
 }
 
@@ -63,11 +72,7 @@ const TYPE_MAP = {
   Star: 'STAR', '**': 'DS',
 };
 
-function lookup(query) {
-  if (!query) return null;
-  const { byKey } = load();
-  const row = byKey.get(normalise(query));
-  if (!row) return null;
+function rowToHit(row) {
   const [name, type, ra, dec, constellation, magnitude] = row;
   const m = name.match(/^([A-Z]+)0*(\d+[A-Za-z]?)$/);
   return {
@@ -81,6 +86,31 @@ function lookup(query) {
     magnitude: magnitude == null ? null : Number(magnitude),
     source: 'OpenNGC',
   };
+}
+
+function lookup(query) {
+  if (!query) return null;
+  const { primary, aliases } = load();
+  const key = normalise(query);
+  // Primary name match always wins.
+  const direct = primary.get(key);
+  if (direct) return rowToHit(direct);
+  // Otherwise pick the brightest alias match, so 'Veil Nebula' picks
+  // the brightest of the NGC 6960/6992/6995 trio rather than whichever
+  // OpenNGC happened to list first.
+  const matches = aliases.get(key);
+  if (!matches || !matches.length) return null;
+  const ranked = [...matches].sort((a, b) => {
+    const ma = a[5] == null ? Infinity : Number(a[5]);
+    const mb = b[5] == null ? Infinity : Number(b[5]);
+    return ma - mb;
+  });
+  const hit = rowToHit(ranked[0]);
+  // Surface the other candidates so the client can offer a picker.
+  if (ranked.length > 1) {
+    hit.alternates = ranked.slice(1, 6).map(rowToHit);
+  }
+  return hit;
 }
 
 module.exports = { lookup };

--- a/server.js
+++ b/server.js
@@ -180,6 +180,15 @@ const AUTH_FAIL_WINDOW_MS = 15 * 60 * 1000;
 const AUTH_FAIL_MAX = 20;
 const authFailures = new Map();
 
+// Write-side rate limit: even with the right password, cap how many
+// POST/PUT/PATCH/DELETE calls a single IP can make per minute. Defends
+// against runaway scripts and stolen-credential abuse. Generous enough
+// that a normal batch-upload session (one stage + one observation per
+// image, every few seconds) stays under the cap.
+const WRITE_WINDOW_MS = 60 * 1000;
+const WRITE_MAX = 120;
+const writeHits = new Map();
+
 function clientIp(req) {
   return req.ip || req.socket?.remoteAddress || 'unknown';
 }
@@ -224,7 +233,21 @@ function basicAuth(req, res, next) {
     ok = timingSafeCompare(pass, ADMIN_PASSWORD);
   }
 
-  if (ok) return next();
+  if (ok) {
+    // Write-side rate limit (POST/PUT/PATCH/DELETE only — GETs stay
+    // unmetered so polling endpoints aren't penalised).
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      const hits = (writeHits.get(ip) || []).filter((t) => now - t < WRITE_WINDOW_MS);
+      if (hits.length >= WRITE_MAX) {
+        res.set('Retry-After', String(Math.ceil(WRITE_WINDOW_MS / 1000)));
+        writeHits.set(ip, hits);
+        return res.status(429).json({ error: 'Too many write requests' });
+      }
+      hits.push(now);
+      writeHits.set(ip, hits);
+    }
+    return next();
+  }
 
   fails.push(now);
   authFailures.set(ip, fails);
@@ -268,9 +291,21 @@ const stageUpload = multer({
   },
 });
 
-app.use('/admin', basicAuth, express.static(path.join(__dirname, 'admin')));
+// Cache policy for JS / CSS / HTML: force the browser to revalidate on
+// every visit so a fresh deploy reaches users without a hard refresh.
+// (The "it's still broken" reports during the upload-form work all
+// traced back to stale module scripts; ETag-only wasn't enough.) Image
+// uploads keep the default "cache forever" semantics — they're
+// addressed by content-unique paths under /uploads.
+function noStoreForCode(res, filePath) {
+  if (/\.(?:js|mjs|css|html)$/i.test(filePath)) {
+    res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+  }
+}
+
+app.use('/admin', basicAuth, express.static(path.join(__dirname, 'admin'), { setHeaders: noStoreForCode }));
 app.use('/uploads', express.static(UPLOAD_DIR));
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, 'public'), { setHeaders: noStoreForCode }));
 
 // Version info — preferred source is the env vars baked in at Docker build
 // time (workflow fills them from the triggering commit). For local `npm
@@ -2026,8 +2061,12 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
   const notes = body.notes ? String(body.notes).trim() : null;
   const observedAt = body.observed_at ? String(body.observed_at).trim() : null;
   const title = body.title ? String(body.title).trim() : null;
-  const clamp = (v, lo, hi) =>
-    v == null || v === '' ? null : Math.max(lo, Math.min(hi, Number(v)));
+  const clamp = (v, lo, hi) => {
+    if (v == null || v === '') return null;
+    const n = Number(v);
+    if (!Number.isFinite(n)) return null;
+    return Math.max(lo, Math.min(hi, n));
+  };
   const rating = clamp(body.rating, 1, 5);
   const seeing = clamp(body.seeing, 1, 5);
   const transparency = clamp(body.transparency, 1, 5);
@@ -2297,8 +2336,12 @@ app.patch('/api/admin/observations/:id', basicAuth, (req, res) => {
 
   // Whitelist of editable columns plus per-column type-coercion / clamping.
   const body = req.body || {};
-  const clamp = (v, lo, hi) =>
-    v == null || v === '' ? null : Math.max(lo, Math.min(hi, Number(v)));
+  const clamp = (v, lo, hi) => {
+    if (v == null || v === '') return null;
+    const n = Number(v);
+    if (!Number.isFinite(n)) return null;
+    return Math.max(lo, Math.min(hi, n));
+  };
   const str = (v, max = 200) =>
     v == null ? null : String(v).trim().slice(0, max) || null;
   const num = (v) => (v == null || v === '' ? null : Number(v));

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -855,6 +855,16 @@ test('smoke', async (t) => {
     // "ic 410" with whitespace and lowercase still works.
     const sloppy = await fetch(`${baseUrl}/api/admin/objects/lookup?q=ic%20410`, { headers: auth });
     assert.equal(sloppy.status, 200);
+
+    // Common-name alias shared by multiple rows ('Eagle Nebula' appears
+    // on both M16 (NGC 6611) and the surrounding nebulosity row).
+    // Regression for #50 — the brightest entry should win and the
+    // others surface as `alternates`.
+    const eagle = await fetch(`${baseUrl}/api/admin/objects/lookup?q=Eagle%20Nebula`, { headers: auth });
+    assert.equal(eagle.status, 200);
+    const e = await eagle.json();
+    assert.ok(Array.isArray(e.alternates) && e.alternates.length >= 1,
+      'shared aliases expose alternates');
   });
 
   await t.test('batch staging: many parallel stages succeed independently', async () => {


### PR DESCRIPTION
Five backlog items, one branch.

### #46 Cache-busting on static JS/CSS/HTML
Static handlers now set `Cache-Control: no-cache, must-revalidate` on every `.js/.mjs/.css/.html` response. Browsers will revalidate ETags on every visit instead of serving stale module scripts. (This is the cause of every "still broken after docker rebuild" report in this session.)

### #47 Broken `/admin/object.html?id=undefined` link
Free-form catalog rows (e.g. typed comet designations with no `list_object`) were rendered as anchors using `object_id` even when it was null. Dropped the anchor when `object_id` is null; label still shows.

### #48 `clamp()` propagating NaN
A crafted POST `{rating:"abc"}` previously wrote NaN — `Number('abc')` is NaN and `Math.max/min` happily propagates. Added a `Number.isFinite` gate that returns null instead.

### #50 OpenNGC alias collisions
Common-name aliases shared by multiple rows ("Eagle Nebula" → M16 + surrounding nebulosity, "Antennae Galaxies" → NGC 4038 + 4039, etc.) used to keep whichever was loaded first. Now `lib/ngc.js` keeps a separate `aliases: Map<key, row[]>` multimap. `lookup()` returns the brightest of the candidates and surfaces the others as `alternates` so the client can render a "did you mean…?" picker.

### #52 Write-side rate limit on admin endpoints
`basicAuth` now tracks POST/PUT/PATCH/DELETE rates per IP independently of auth failures. Window 60 s, cap 120 writes — generous for a real batch upload session, mean enough to slow a runaway script with stolen credentials. GETs stay unmetered so polling endpoints aren't penalised.

### Tests
+1 smoke: shared common-name alias returns `alternates`.

## Test plan
- [x] `npm test` green: 32/32


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_