### PR TITLE
Equipment usage stats: nights / frames / hours / avg rating per telescope

### DIFF
--- a/admin/dashboard.js
+++ b/admin/dashboard.js
@@ -109,9 +109,31 @@ function renderTelescopes(telescopes) {
     wrap.appendChild(el('span', { class: 'dim', text: 'No telescopes logged yet.' }));
     return;
   }
+  // Render as a small table — chips lost too much info now that the
+  // rollup carries nights / frames / integration-hours / avg rating.
+  const tbl = el('table', { style: 'width:auto; font-size:0.85rem;' });
+  const head = el('thead', {}, el('tr', {},
+    el('th', { text: 'Telescope' }),
+    el('th', { text: 'Obs' }),
+    el('th', { text: 'Nights' }),
+    el('th', { text: 'Frames' }),
+    el('th', { text: 'Hours' }),
+    el('th', { text: 'Avg ★' }),
+  ));
+  const body = el('tbody');
   for (const t of telescopes) {
-    wrap.appendChild(el('span', { class: 'chip', text: `${t.telescope} · ${t.count}` }));
+    body.appendChild(el('tr', {},
+      el('td', { text: t.telescope }),
+      el('td', { text: String(t.count) }),
+      el('td', { text: t.nights != null ? String(t.nights) : '—' }),
+      el('td', { text: t.frames != null ? String(t.frames) : '—' }),
+      el('td', { text: t.integration_hours != null ? `${t.integration_hours.toFixed(1)} h` : '—' }),
+      el('td', { text: t.avg_rating != null ? Number(t.avg_rating).toFixed(2) : '—' }),
+    ));
   }
+  tbl.appendChild(head);
+  tbl.appendChild(body);
+  wrap.appendChild(tbl);
 }
 
 function renderHeatmap(rows) {

--- a/admin/index.html
+++ b/admin/index.html
@@ -76,7 +76,7 @@
 
       <section class="section">
         <h2>Telescope usage</h2>
-        <div id="telescopes" class="chip-row"></div>
+        <div id="telescopes"></div>
       </section>
 
       <section class="section">

--- a/backlog.md
+++ b/backlog.md
@@ -192,7 +192,7 @@ None of these have been started; pick the ones that fit your workflow.
 42. ✅ **iCalendar dark-moon weekend feed** — `/api/calendar/dark-moon.ics`
     serves Friday-Sunday windows around each new moon for the next year.
     Subscribe in any calendar app.
-43. **Equipment usage stats per scope** — "Seestar S30 Pro: 47 nights,
+43. ✅ **Equipment usage stats per scope** — "Seestar S30 Pro: 47 nights,
     1,200 frames, avg rating 3.8" panel under the existing telescope
     chips. Pure aggregation, no schema change.
 44. **Slack/Discord webhook on new observation** — outbound POST to a

--- a/server.js
+++ b/server.js
@@ -1722,9 +1722,30 @@ app.get('/api/admin/stats', basicAuth, (_req, res) => {
     )
     .all();
 
+  // Per-telescope rollup: not just the observation count, but the things
+  // a Seestar / smart-scope user actually cares about — how many nights
+  // they've taken it out, how many frames stacked, total integration
+  // hours, average rating. The integration-hours expression uses the
+  // same heuristic as the lifetime panel (treat exposures > 600 s as
+  // pre-aggregated totals so we don't double-count).
   const telescopes = db
     .prepare(
-      `SELECT telescope, COUNT(*) AS count
+      `SELECT telescope,
+              COUNT(*) AS count,
+              COUNT(DISTINCT substr(COALESCE(observed_at, created_at), 1, 10)) AS nights,
+              SUM(COALESCE(stack_count, 1)) AS frames,
+              ROUND(
+                SUM(
+                  CASE
+                    WHEN COALESCE(exposure_seconds, 0) <= 0 THEN 0
+                    WHEN COALESCE(exposure_seconds, 0) <= 600
+                      THEN COALESCE(stack_count, 1) * exposure_seconds
+                    ELSE exposure_seconds
+                  END
+                ) / 3600.0,
+                1
+              ) AS integration_hours,
+              ROUND(AVG(rating), 2) AS avg_rating
          FROM observations
          WHERE telescope IS NOT NULL AND telescope != ''
          GROUP BY telescope

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -615,6 +615,15 @@ test('smoke', async (t) => {
     assert.equal(typeof data.lifetime.observations_this_year, 'number');
     assert.equal(typeof data.lifetime.longest_streak_days, 'number');
     assert.equal(typeof data.lifetime.current_streak_days, 'number');
+    // Per-telescope rollup: every entry must carry the richer fields,
+    // not just an observation count.
+    assert.ok(Array.isArray(data.telescopes), 'telescopes block present');
+    for (const t of data.telescopes) {
+      assert.equal(typeof t.telescope, 'string');
+      assert.equal(typeof t.count, 'number');
+      assert.equal(typeof t.nights, 'number');
+      assert.ok(t.integration_hours == null || typeof t.integration_hours === 'number');
+    }
   });
 
   await t.test('SQM round-trips through upload + edit', async () => {


### PR DESCRIPTION
Closes backlog #43.

The "Telescope usage" section on the admin dashboard was a chip row showing just `Seestar S30 Pro · 47`. Replacing it with the richer rollup a Seestar / smart-scope user actually cares about:

| Telescope | Obs | Nights | Frames | Hours | Avg ★ |
|---|---|---|---|---|---|
| Seestar S30 Pro | 47 | 12 | 1,200 | 23.4 h | 3.85 |

### Server
`/api/admin/stats` now returns per-telescope `{count, nights, frames, integration_hours, avg_rating}`. Hours uses the same heuristic as the lifetime panel (treat `exposure_seconds > 600 s` as a pre-aggregated total so we don't double-count).

### Client
Chip row swapped for a compact table. Empty state ("No telescopes logged yet") is unchanged.

## Test plan
- [x] `npm test` green: 32/32 — smoke test now asserts the rollup carries the new fields.
- [ ] Manual: load `/admin/`, confirm the Telescope usage section renders the new columns


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_