### PR TITLE
Seestar planner: telescope filter (S50/S30/S30 Pro) + date picker

### DIFF
--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -22,6 +22,9 @@ mountDurationPicker(document.getElementById('duration-filter'), () => {
   if (rows.children.length) load();
 });
 
+const dateInput = document.getElementById('date-input');
+const timeInput = document.getElementById('time-input');
+const telescopeInput = document.getElementById('telescope-input');
 const latInput = document.getElementById('lat-input');
 const lonInput = document.getElementById('lon-input');
 const minAltInput = document.getElementById('min-alt-input');
@@ -30,9 +33,31 @@ const includeObserved = document.getElementById('include-observed');
 const locateBtn = document.getElementById('locate-btn');
 const runBtn = document.getElementById('run-btn');
 const status = document.getElementById('status');
+const scopeLine = document.getElementById('scope-line');
 const moonLine = document.getElementById('moon-line');
 const windowLine = document.getElementById('window-line');
 const rows = document.getElementById('rows');
+
+// Default date / time to "now" in the user's local timezone — same
+// pattern the regular planner uses so 11pm-local doesn't roll into
+// the next UTC day. Persist telescope choice in localStorage so it
+// carries between visits.
+const pad = (n) => String(n).padStart(2, '0');
+const nowLocal = new Date();
+dateInput.value = `${nowLocal.getFullYear()}-${pad(nowLocal.getMonth() + 1)}-${pad(nowLocal.getDate())}`;
+timeInput.value = `${pad(nowLocal.getHours())}:${pad(nowLocal.getMinutes())}`;
+try {
+  const storedScope = localStorage.getItem('deepskylog.seestar_scope') || 'any';
+  if ([...telescopeInput.options].some((o) => o.value === storedScope)) {
+    telescopeInput.value = storedScope;
+  }
+} catch {}
+telescopeInput.addEventListener('change', () => {
+  try { localStorage.setItem('deepskylog.seestar_scope', telescopeInput.value); } catch {}
+  load();
+});
+dateInput.addEventListener('change', () => load());
+timeInput.addEventListener('change', () => load());
 
 const STORE_KEY = 'deepskylog.location';
 let stored = null;
@@ -67,11 +92,19 @@ async function load() {
 
   status.textContent = 'Planning…';
   rows.innerHTML = '';
+  // Combine date + time as local — the resulting Date is the correct
+  // UTC instant. Falls back to "now" if either input is empty (e.g.
+  // user cleared the date and tapped Plan).
+  let startISO = new Date().toISOString();
+  if (dateInput.value && timeInput.value) {
+    const candidate = new Date(`${dateInput.value}T${timeInput.value}`);
+    if (!Number.isNaN(candidate.getTime())) startISO = candidate.toISOString();
+  }
   const params = new URLSearchParams({
     lat: String(lat), lon: String(lon),
     min_alt: String(minAlt), max_alt: String(maxAlt),
-    // Start is always "now" — that's the whole point of the page.
-    start: new Date().toISOString(),
+    start: startISO,
+    telescope: telescopeInput.value || 'any',
   });
   if (includeObserved.checked) params.set('include_observed', '1');
   const catParam = selectionToParam(getCatalogSelection());
@@ -90,6 +123,17 @@ async function load() {
   }
 
   const moonPct = (data.moon.illumination * 100).toFixed(0);
+  // Scope summary: name + brief sweet-spot blurb + magnitude cap so
+  // the user knows which targets are being filtered out.
+  if (data.scope) {
+    const capBit = data.scope.max_magnitude != null
+      ? ` · cap ≤ mag ${data.scope.max_magnitude.toFixed(1)}`
+      : ' · no magnitude filter';
+    const notesBit = data.scope.notes ? ` · ${data.scope.notes}` : '';
+    scopeLine.textContent = `Scope: ${data.scope.name}${capBit}${notesBit}`;
+  } else {
+    scopeLine.textContent = '';
+  }
   moonLine.textContent = `Moon at start: ${data.moon.name} (${moonPct}% illuminated)`;
 
   const start = new Date(data.window.start);

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -27,6 +27,23 @@
 
       <div class="toolbar">
         <label>
+          Date
+          <input id="date-input" type="date" />
+        </label>
+        <label>
+          Time
+          <input id="time-input" type="time" />
+        </label>
+        <label>
+          Telescope
+          <select id="telescope-input">
+            <option value="any">Any</option>
+            <option value="s50">Seestar S50</option>
+            <option value="s30">Seestar S30</option>
+            <option value="s30pro">Seestar S30 Pro</option>
+          </select>
+        </label>
+        <label>
           Latitude
           <input id="lat-input" type="number" step="any" placeholder="51.4769" />
         </label>
@@ -53,6 +70,7 @@
         <span id="status" class="dim" style="margin-left:auto;"></span>
       </div>
 
+      <div id="scope-line" class="dim" style="margin-bottom: 0.25rem;"></div>
       <div id="moon-line" class="dim" style="margin-bottom: 0.25rem;"></div>
       <div id="window-line" class="dim" style="margin-bottom: 0.75rem;"></div>
 

--- a/server.js
+++ b/server.js
@@ -657,6 +657,33 @@ app.get('/api/planner', (req, res) => {
 // least min_alt (default 50°), and at slot end it's no higher than
 // max_alt (default 80°) so the tube doesn't have to swing through
 // zenith. Each target is assigned to at most one slot.
+// Per-scope tuning for the Seestar planner. Magnitude caps are based on
+// what each model can actually pull faint detail out of in a one-night
+// stack at f/5; targets with NULL magnitudes (ephemeris bodies, free-
+// form rows) always pass through regardless of the chosen scope.
+//
+// FOV / aperture context, for the curious:
+//   S50      — 50 mm f/5, 250 mm fl, ~1.3° × 0.7° FOV. Best on
+//              medium-bright DSOs, planets, anything that needs scale.
+//   S30      — 30 mm f/5, 150 mm fl, ~2.1° × 1.2° FOV. Best on wide-
+//              field nebulae and bright star clusters; loses small
+//              compact targets in the bigger pixels.
+//   S30 Pro  — same optics as S30 with a better sensor + EAF; pulls
+//              ~0.5 mag deeper.
+const SEESTAR_SCOPES = {
+  any:    { name: 'Any',            max_magnitude: null },
+  s50:    { name: 'Seestar S50',    max_magnitude: 11.0,
+            notes: '50 mm f/5, ~1.3°×0.7° FOV. Sweet spot: medium-bright DSOs, planets.' },
+  s30:    { name: 'Seestar S30',    max_magnitude: 10.0,
+            notes: '30 mm f/5, ~2.1°×1.2° FOV. Sweet spot: wide-field nebulae, bright clusters.' },
+  s30pro: { name: 'Seestar S30 Pro', max_magnitude: 10.5,
+            notes: 'S30 FOV with a better sensor + EAF — about half a magnitude deeper.' },
+};
+function parseSeestarScope(raw) {
+  const k = String(raw || '').toLowerCase().replace(/\s+/g, '');
+  return SEESTAR_SCOPES[k] ? k : 'any';
+}
+
 app.get('/api/seestar-planner', (req, res) => {
   const lat = Number(req.query.lat);
   const lon = Number(req.query.lon);
@@ -666,6 +693,8 @@ app.get('/api/seestar-planner', (req, res) => {
   const minAlt = Number.isFinite(Number(req.query.min_alt)) ? Number(req.query.min_alt) : 50;
   const maxAlt = Number.isFinite(Number(req.query.max_alt)) ? Number(req.query.max_alt) : 80;
   const includeObserved = req.query.include_observed === '1';
+  const scopeKey = parseSeestarScope(req.query.telescope);
+  const scope = SEESTAR_SCOPES[scopeKey];
   const start = req.query.start ? new Date(req.query.start) : new Date();
   if (Number.isNaN(start.getTime())) {
     return res.status(400).json({ error: 'invalid start time' });
@@ -783,6 +812,11 @@ app.get('/api/seestar-planner', (req, res) => {
     for (const row of rows) {
       if (!includeObserved && row.observed) continue;
       if (assignedIds.has(row.id)) continue;
+      // Telescope cap: drop targets too faint for the chosen scope.
+      // NULL magnitudes (planets, ephemeris, free-form) always pass.
+      if (scope.max_magnitude != null
+          && row.magnitude != null
+          && Number(row.magnitude) > scope.max_magnitude) continue;
       const dur = durationFor(row.object_type);
       const slotEndMs = cursor + dur * 60_000;
       if (slotEndMs > sessionEnd.getTime()) continue;
@@ -838,6 +872,7 @@ app.get('/api/seestar-planner', (req, res) => {
     max_altitude: maxAlt,
     moon: moonPhase(start),
     durations: { ...DEFAULT_DURATIONS, ...userDurations, _default: defaultDur },
+    scope: { key: scopeKey, ...scope },
     slots: plan,
   });
 });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -789,6 +789,30 @@ test('smoke', async (t) => {
     }
   });
 
+  await t.test('Seestar planner: telescope filter caps target magnitude', async () => {
+    const start = new Date('2026-01-15T22:00:00Z').toISOString();
+    // S30 caps at mag 10. Every assigned target with a known magnitude
+    // must respect that; nulls (planets etc.) pass through.
+    const s30 = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&min_alt=10&max_alt=80&telescope=s30`,
+    );
+    assert.equal(s30.scope?.key, 's30');
+    assert.equal(s30.scope?.max_magnitude, 10.0);
+    for (const s of s30.slots) {
+      if (!s.target) continue;
+      if (s.target.magnitude != null) {
+        assert.ok(s.target.magnitude <= 10.0,
+          `S30 admitted mag ${s.target.magnitude} on ${s.target.catalog}${s.target.catalog_number}`);
+      }
+    }
+    // Unknown scope falls back to "any" — no filter applied.
+    const fallback = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&min_alt=10&max_alt=80&telescope=skywatcher-150p`,
+    );
+    assert.equal(fallback.scope?.key, 'any');
+    assert.equal(fallback.scope?.max_magnitude, null);
+  });
+
   await t.test('Seestar planner returns variable-duration slots in alt window', async () => {
     // Pick a start far from sunrise at the target location so we always
     // get a non-trivial slot list. Start at 2026-01-15 22:00 UTC,


### PR DESCRIPTION
Two upgrades to the Seestar planner toolbar.

## Telescope selector
Default **Any** preserves the current behaviour. Picking a specific model caps target magnitude by the practical depth of that scope at f/5 in a one-night smart-scope stack:

| Scope | Cap | Sweet spot |
|---|---|---|
| Seestar S50 | ≤ 11.0 | 50 mm, ~1.3° × 0.7° FOV. Medium-bright DSOs, planets. |
| Seestar S30 | ≤ 10.0 | 30 mm, ~2.1° × 1.2° FOV. Wide-field nebulae, bright clusters. |
| Seestar S30 Pro | ≤ 10.5 | Same FOV as S30 with a better sensor + EAF — about half a magnitude deeper. |

NULL magnitudes (planets / ephemeris bodies / free-form rows) always pass through so they don't disappear with the filter on. The chosen scope and its sweet-spot blurb render in a "Scope: …" line under the toolbar so you can see what got filtered.

## Date / time pickers
Replaces the implicit "always now" start. Defaults to today + current local time; pick any future date+time to plan ahead. Both inputs auto-re-plan on change. Empty / invalid input gracefully falls back to "now".

## Server
- `SEESTAR_SCOPES` profile map keyed by `any / s50 / s30 / s30pro` with `name / max_magnitude / notes`.
- `parseSeestarScope(req.query.telescope)` accepts unknown values and falls back to `any`.
- Filter applied inside the existing per-slot picker loop so it composes cleanly with catalog / type / duration filters.
- Response now includes `scope: { key, name, max_magnitude, notes }`.

## Client
- Persists the scope choice in `localStorage` under `deepskylog.seestar_scope`.
- Date / time inputs combine into the `start` query param.

## Tests
+1 smoke: `telescope=s30` admits only magnitude ≤ 10 rows (NULL magnitudes ok); unknown scope key falls back to `any` (no `max_magnitude` cap).

## Test plan
- [x] `npm test` green: 33/33
- [ ] Manual: `/seestar.html` → flip Telescope to S50 → re-plan, faint targets drop out; pick a date a week ahead → plan rebuilds for that night.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_