### PR TITLE
Migration 14: reset MWWF rows so PR 69 renames propagate to existing installs

### DIFF
--- a/db/schema.js
+++ b/db/schema.js
@@ -194,6 +194,21 @@ const MIGRATIONS = [
       ALTER TABLE observations ADD COLUMN sqm REAL;
     `,
   },
+  {
+    id: 14,
+    name: 'reset_milky_way_wide_for_renamed_entries',
+    // The wide-field MW list shipped initially with astrophysics-jargon
+    // names ('Galactic Core (Sgr A* region)', 'Vela SNR', etc.). v2
+    // renamed every row to its canonical 'slew to <target>' form and
+    // dropped the too-southern entries. Re-seed only runs when the row
+    // count is below the new entry count, so existing installs would
+    // keep the old names forever. Wipe the MWWF rows here so the seed
+    // loader inserts the new ones on next boot. Cross-list aliases
+    // re-tick on the next upload.
+    up: `
+      DELETE FROM list_objects WHERE catalog = 'MWWF';
+    `,
+  },
 ];
 
 module.exports = { MIGRATIONS };


### PR DESCRIPTION
PR #69 renamed the Milky Way wide-field entries from astrophysics-speak ("Galactic Core (Sgr A* region)") to slew-target names ("Sagittarius Teapot pour · slew to M8"), but existing installs don't see them. Verified the seed loader at `db/index.js:72` short-circuits with `if (count >= entries.length) return` — the prod DB has 15 MWWF rows (PR 68's set including Carina and Vela), the new seed has 13, so 15 ≥ 13 and reseed does nothing.

Migration 14 deletes the MWWF rows so the next boot reseeds from the v2 file. Cross-list aliases re-tick any `list_completions` the next time the user uploads a matching shot.

Trade-off: any list_completions referencing the old MWWF rows cascade-delete (the ON DELETE CASCADE on `list_completions.list_object_id`). The underlying observations stay — their `object_id` gets nulled to free-form. Realistically nobody's logged observations against those rows in the few hours between PR 68 and now.

## Test plan
- [x] `npm test` green: 33/33
- [ ] Manual: deploy → boot → check that `/list.html?slug=milky-way-wide` shows the 13 v2 names


---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_