### PR TITLE
Catalog cross-reference: see every name a target goes by, link the rest

### DIFF
--- a/admin/crossref.html
+++ b/admin/crossref.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DeepSkyLog &mdash; Catalog cross-reference</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet" href="/admin/admin.css" />
+    <style>
+      .xref-toolbar {
+        display: flex; gap: 0.75rem; align-items: flex-end;
+        flex-wrap: wrap; margin-bottom: 1rem;
+      }
+      .xref-toolbar label { display: flex; flex-direction: column; gap: 0.25rem; }
+      .xref-toolbar .dim { font-size: 0.8rem; }
+      .xref-toolbar input[type="text"], .xref-toolbar input[type="number"] {
+        background: #000; color: var(--fg); border: 1px solid var(--accent);
+        border-radius: 6px; padding: 0.45rem 0.6rem; font: inherit;
+      }
+      .xref-toolbar .check { flex-direction: row; align-items: center; gap: 0.4rem; }
+
+      .xref-group {
+        border: 1px solid var(--accent);
+        border-left: 8px solid var(--accent-2);
+        border-radius: 0 12px 0 12px;
+        background: #0c0c0c;
+        padding: 0.8rem 1rem;
+        margin-bottom: 0.7rem;
+      }
+      .xref-group h3 { margin: 0 0 0.35rem; color: var(--peach); font-size: 1.05rem; }
+      .xref-group .coord { color: var(--fg-dim); font-size: 0.8rem; font-weight: 400; margin-left: 0.5rem; }
+      .desig-row { display: flex; gap: 0.35rem; flex-wrap: wrap; margin: 0.35rem 0; }
+      .desig {
+        font-family: var(--condensed); letter-spacing: 0.04em;
+        background: #1a1208; border: 1px solid var(--accent);
+        border-radius: var(--pill); padding: 0.12rem 0.6rem; font-size: 0.82rem;
+        color: var(--lcars-cream);
+      }
+      .list-badges { display: flex; gap: 0.35rem; flex-wrap: wrap; margin-top: 0.3rem; }
+      .list-badge {
+        font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em;
+        background: var(--lcars-blue); color: #000; border-radius: var(--pill);
+        padding: 0.1rem 0.55rem; font-weight: 700; font-family: var(--condensed);
+      }
+      .xref-members { margin-top: 0.5rem; display: grid; gap: 0.2rem; }
+      .xref-member { font-size: 0.85rem; color: var(--fg-dim); }
+      .xref-member a { color: var(--accent); text-decoration: none; }
+      .xref-member a:hover { color: var(--peach); }
+
+      .sugg {
+        border: 1px solid var(--warn);
+        border-left: 8px solid var(--warn);
+        border-radius: 0 12px 0 12px;
+        background: #150f05; padding: 0.7rem 1rem; margin-bottom: 0.6rem;
+        display: flex; justify-content: space-between; align-items: center;
+        gap: 1rem; flex-wrap: wrap;
+      }
+      .sugg .pair { font-size: 0.9rem; }
+      .sugg .sep { color: var(--warn); font-weight: 700; }
+      .sugg-status { font-size: 0.82rem; color: var(--fg-dim); }
+      .empty-note { color: var(--fg-dim); padding: 0.5rem 0; }
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span class="brand-name">DeepSkyLog · Admin</span>
+      </div>
+      <nav class="site-nav">
+        <a href="/">Public site</a>
+        <a href="/admin/">Dashboard</a>
+        <a href="/admin/observations.html">Observations</a>
+        <a href="/admin/crossref.html" class="active">Cross-reference</a>
+        <a href="/admin/equipment.html">Equipment</a>
+        <a href="/admin/upload.html">Upload</a>
+      </nav>
+    </header>
+    <main>
+      <div class="dash-header">
+        <div>
+          <h1 class="page-title">Catalog cross-reference</h1>
+          <p class="page-subtitle">
+            Every catalog entry grouped by the physical sky target it names.
+            One target, many designations &mdash; review the matches and link
+            any that the seed aliases missed.
+          </p>
+        </div>
+      </div>
+
+      <section class="section">
+        <div id="xref-counts" class="stats-grid">
+          <div class="stat"><span class="stat-label">Targets</span><span class="stat-value" id="cnt-targets">—</span></div>
+          <div class="stat"><span class="stat-label">Multi-name</span><span class="stat-value" id="cnt-multi">—</span></div>
+          <div class="stat"><span class="stat-label">Catalog entries</span><span class="stat-value" id="cnt-entries">—</span></div>
+          <div class="stat"><span class="stat-label">Unlinked matches</span><span class="stat-value" id="cnt-sugg">—</span></div>
+        </div>
+      </section>
+
+      <section class="section" id="suggestions-section" hidden>
+        <h2>Possible unlinked matches</h2>
+        <p class="dim" style="margin-top:-0.4rem;">
+          These targets sit within the search radius but aren't alias-linked.
+          Linking adds each one's designation to the other so future uploads
+          tick both lists.
+        </p>
+        <div id="suggestions"></div>
+      </section>
+
+      <section class="section">
+        <h2>Targets</h2>
+        <div class="xref-toolbar">
+          <label>
+            <span class="dim">Filter by name or designation</span>
+            <input type="text" id="filter" placeholder="e.g. Orion, M42, NGC 1976" autocomplete="off" />
+          </label>
+          <label>
+            <span class="dim">Match radius (arc-min)</span>
+            <input type="number" id="tol" min="0" max="120" step="0.5" value="6" style="width:7rem;" />
+          </label>
+          <label class="check">
+            <input type="checkbox" id="multi-only" checked />
+            <span class="dim">Only multi-name targets</span>
+          </label>
+        </div>
+        <div id="groups"><p class="empty-note">Loading&hellip;</p></div>
+      </section>
+    </main>
+    <script type="module" src="/admin/crossref.js"></script>
+    <script type="module" src="/admin/version.js"></script>
+    <script type="module" src="/js/site-name.js"></script>
+  </body>
+</html>

--- a/admin/crossref.js
+++ b/admin/crossref.js
@@ -1,0 +1,160 @@
+import { fetchJson, el, typeLabel } from '/js/common.js';
+
+const groupsEl = document.getElementById('groups');
+const suggSection = document.getElementById('suggestions-section');
+const suggEl = document.getElementById('suggestions');
+const filterEl = document.getElementById('filter');
+const tolEl = document.getElementById('tol');
+const multiOnlyEl = document.getElementById('multi-only');
+
+const state = { data: null };
+
+function formatCoord(g) {
+  if (g.ra_hours == null || g.dec_degrees == null) return '';
+  const ra = Number(g.ra_hours).toFixed(2);
+  const dec = (g.dec_degrees >= 0 ? '+' : '') + Number(g.dec_degrees).toFixed(2);
+  return `RA ${ra}h · Dec ${dec}°`;
+}
+
+function memberLine(m) {
+  const desig = `${m.catalog}${m.catalog_number}`;
+  return el('div', { class: 'xref-member' },
+    el('a', { href: `/admin/object.html?id=${encodeURIComponent(m.id)}`, text: desig }),
+    el('span', { text: ` · ${m.list_name}` }),
+    m.object_type ? el('span', { text: ` · ${typeLabel(m.object_type)}` }) : null,
+    m.name ? el('span', { text: ` · ${m.name}` }) : null,
+  );
+}
+
+function groupCard(g) {
+  const card = el('div', { class: 'xref-group' });
+  card.appendChild(el('h3', {},
+    document.createTextNode(g.name || g.designations[0] || g.key),
+    el('span', { class: 'coord', text: formatCoord(g) }),
+  ));
+
+  const desigRow = el('div', { class: 'desig-row' });
+  for (const d of g.designations) desigRow.appendChild(el('span', { class: 'desig', text: d }));
+  card.appendChild(desigRow);
+
+  const badges = el('div', { class: 'list-badges' });
+  for (const l of g.lists) badges.appendChild(el('span', { class: 'list-badge', text: l.name }));
+  card.appendChild(badges);
+
+  const members = el('div', { class: 'xref-members' });
+  for (const m of g.members) members.appendChild(memberLine(m));
+  card.appendChild(members);
+
+  return card;
+}
+
+function matchesFilter(g, q) {
+  if (!q) return true;
+  const hay = [
+    g.name || '', g.key,
+    ...g.designations,
+    ...g.members.map((m) => `${m.catalog}${m.catalog_number} ${m.name || ''}`),
+  ].join(' ').toLowerCase();
+  return hay.includes(q);
+}
+
+function renderGroups() {
+  if (!state.data) return;
+  const q = filterEl.value.trim().toLowerCase();
+  const multiOnly = multiOnlyEl.checked;
+  const shown = state.data.groups.filter(
+    (g) => (!multiOnly || g.multi) && matchesFilter(g, q),
+  );
+
+  groupsEl.innerHTML = '';
+  if (!shown.length) {
+    groupsEl.appendChild(el('p', { class: 'empty-note', text: 'No targets match.' }));
+    return;
+  }
+  for (const g of shown) groupsEl.appendChild(groupCard(g));
+}
+
+async function linkPair(sugg, button, statusEl) {
+  const ids = [...new Set([...sugg.a.ids, ...sugg.b.ids])];
+  button.disabled = true;
+  statusEl.textContent = 'Linking…';
+  try {
+    const res = await fetch('/api/admin/crossref/link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || `HTTP ${res.status}`);
+    }
+    statusEl.textContent = 'Linked — reloading…';
+    await load();
+  } catch (err) {
+    button.disabled = false;
+    statusEl.textContent = `Failed: ${err.message}`;
+  }
+}
+
+function suggestionRow(sugg) {
+  const row = el('div', { class: 'sugg' });
+  const label = (side) => side.name
+    ? `${side.name} (${side.designations.join(', ')})`
+    : side.designations.join(', ');
+  row.appendChild(el('div', { class: 'pair' },
+    el('span', { text: label(sugg.a) }),
+    el('span', { text: '  ⇄  ' }),
+    el('span', { text: label(sugg.b) }),
+    el('span', { text: '  ' }),
+    el('span', { class: 'sep', text: `${sugg.separation_arcmin}′ apart` }),
+  ));
+  const status = el('span', { class: 'sugg-status' });
+  const btn = el('button', { class: 'button-link', text: 'Link as same target' });
+  btn.addEventListener('click', () => linkPair(sugg, btn, status));
+  row.appendChild(el('div', { class: 'dash-actions', style: 'align-items:center;' }, status, btn));
+  return row;
+}
+
+function renderSuggestions() {
+  const list = state.data?.suggestions || [];
+  if (!list.length) {
+    suggSection.hidden = true;
+    return;
+  }
+  suggSection.hidden = false;
+  suggEl.innerHTML = '';
+  for (const s of list) suggEl.appendChild(suggestionRow(s));
+}
+
+function renderCounts() {
+  const c = state.data?.counts || {};
+  document.getElementById('cnt-targets').textContent = c.targets ?? '—';
+  document.getElementById('cnt-multi').textContent = c.multi ?? '—';
+  document.getElementById('cnt-entries').textContent = c.entries ?? '—';
+  document.getElementById('cnt-sugg').textContent = c.suggestions ?? '—';
+}
+
+async function load() {
+  const arcmin = Math.max(0, Number(tolEl.value) || 0);
+  const tolDeg = arcmin / 60;
+  try {
+    state.data = await fetchJson(`/api/admin/crossref?tol=${encodeURIComponent(tolDeg)}`);
+  } catch (err) {
+    groupsEl.innerHTML = '';
+    groupsEl.appendChild(el('p', { class: 'empty-note', text: `Failed to load: ${err.message}` }));
+    return;
+  }
+  renderCounts();
+  renderSuggestions();
+  renderGroups();
+}
+
+filterEl.addEventListener('input', renderGroups);
+multiOnlyEl.addEventListener('change', renderGroups);
+let tolTimer = null;
+tolEl.addEventListener('input', () => {
+  clearTimeout(tolTimer);
+  tolTimer = setTimeout(load, 400);
+});
+
+load();

--- a/admin/equipment.html
+++ b/admin/equipment.html
@@ -17,6 +17,7 @@
         <a href="/">Public site</a>
         <a href="/admin/">Dashboard</a>
         <a href="/admin/observations.html">Observations</a>
+        <a href="/admin/crossref.html">Cross-reference</a>
         <a href="/admin/equipment.html" class="active">Equipment</a>
         <a href="/admin/upload.html">Upload</a>
       </nav>

--- a/admin/index.html
+++ b/admin/index.html
@@ -17,6 +17,7 @@
         <a href="/">Public site</a>
         <a href="/admin/" class="active">Dashboard</a>
         <a href="/admin/observations.html">Observations</a>
+        <a href="/admin/crossref.html">Cross-reference</a>
         <a href="/admin/equipment.html">Equipment</a>
         <a href="/admin/upload.html">Upload</a>
       </nav>
@@ -29,6 +30,7 @@
         </div>
         <div class="dash-actions">
           <a class="button-link" href="/admin/upload.html">+ New observation</a>
+          <a class="button-link ghost-link" href="/admin/crossref.html" title="Group catalog entries by the sky target they name and link multi-name targets">Catalog cross-reference</a>
           <a class="button-link ghost-link" href="/api/observations.csv">Download CSV</a>
           <a class="button-link ghost-link" href="/api/calendar/dark-moon.ics" title="iCalendar feed of new-moon weekends">Dark-moon .ics</a>
           <a class="button-link ghost-link" href="/admin/shortcut.html" title="Install an iOS share-sheet shortcut for one-tap uploads from the Seestar app">iOS shortcut</a>

--- a/admin/object.html
+++ b/admin/object.html
@@ -17,6 +17,7 @@
         <a href="/">Public site</a>
         <a href="/admin/">Dashboard</a>
         <a href="/admin/observations.html">Observations</a>
+        <a href="/admin/crossref.html">Cross-reference</a>
         <a href="/admin/equipment.html">Equipment</a>
         <a href="/admin/upload.html">Upload</a>
       </nav>

--- a/admin/observations.html
+++ b/admin/observations.html
@@ -17,6 +17,7 @@
         <a href="/">Public site</a>
         <a href="/admin/">Dashboard</a>
         <a href="/admin/observations.html" class="active">Observations</a>
+        <a href="/admin/crossref.html">Cross-reference</a>
         <a href="/admin/equipment.html">Equipment</a>
         <a href="/admin/upload.html">Upload</a>
       </nav>

--- a/admin/shortcut.html
+++ b/admin/shortcut.html
@@ -46,6 +46,7 @@
         <a href="/">Public site</a>
         <a href="/admin/">Dashboard</a>
         <a href="/admin/observations.html">Observations</a>
+        <a href="/admin/crossref.html">Cross-reference</a>
         <a href="/admin/equipment.html">Equipment</a>
         <a href="/admin/upload.html">Upload</a>
       </nav>

--- a/admin/upload.html
+++ b/admin/upload.html
@@ -17,6 +17,7 @@
         <a href="/">Public site</a>
         <a href="/admin/">Dashboard</a>
         <a href="/admin/observations.html">Observations</a>
+        <a href="/admin/crossref.html">Cross-reference</a>
         <a href="/admin/equipment.html">Equipment</a>
         <a href="/admin/upload.html" class="active">Upload</a>
       </nav>

--- a/backlog.md
+++ b/backlog.md
@@ -81,6 +81,13 @@ Items prefixed with ✅ are shipped on `main`; the others are still open.
   rotated by `solved_orientation_deg`. RA/Dec grid + 50 brightest stars
   + procedural ambient star field for orientation. Hover for tooltip,
   click to open the observation detail page.
+- ✅ **Catalog cross-reference** — `/admin/crossref.html` groups every
+  catalog entry by the physical sky target it names (connected components
+  of the alias graph), so one target shows all its designations across
+  every list (M42 = NGC1976 = Sh2-275 …). Flags unlinked entries within a
+  tunable arc-minute radius as "possible matches" with a one-click link
+  action that adds the missing aliases. Backed by `GET /api/admin/crossref`
+  and `POST /api/admin/crossref/link`.
 
 ## Future ideas
 

--- a/server.js
+++ b/server.js
@@ -1997,6 +1997,185 @@ app.get('/api/admin/objects', basicAuth, (req, res) => {
   res.json(rows);
 });
 
+// Angular separation (degrees) between two sky points. RA in decimal hours,
+// Dec in decimal degrees. Used by the cross-reference tool to spot catalog
+// entries that sit on the same patch of sky but aren't alias-linked yet.
+function angularSepDeg(ra1h, dec1, ra2h, dec2) {
+  const D2R = Math.PI / 180;
+  const r1 = ra1h * 15 * D2R;
+  const r2 = ra2h * 15 * D2R;
+  const d1 = dec1 * D2R;
+  const d2 = dec2 * D2R;
+  let c = Math.sin(d1) * Math.sin(d2) + Math.cos(d1) * Math.cos(d2) * Math.cos(r1 - r2);
+  c = Math.max(-1, Math.min(1, c));
+  return Math.acos(c) / D2R;
+}
+
+// Cross-reference tool: group every catalog entry into the physical sky
+// target it refers to. Two entries belong to the same target when they share
+// a designation through the alias graph (e.g. M42 ⇄ NGC1976 ⇄ Sh2-275). We
+// also surface pairs of *unlinked* groups that sit within `tol` degrees of
+// each other, so the admin can review and link likely-same targets that the
+// seed aliases missed.
+app.get('/api/admin/crossref', basicAuth, (req, res) => {
+  const tol = Math.min(Math.max(Number(req.query.tol) || 0.1, 0), 2); // degrees
+  const rows = db
+    .prepare(
+      `SELECT lo.id, lo.catalog, lo.catalog_number, lo.name, lo.object_type,
+              lo.ra_hours, lo.dec_degrees, lo.magnitude, lo.aliases,
+              l.slug AS list_slug, l.name AS list_name
+         FROM list_objects lo JOIN lists l ON l.id = lo.list_id`,
+    )
+    .all();
+
+  const graph = buildAliasGraph(db);
+
+  // Canonical group key for a token = the alphabetically-first token in its
+  // connected component, so the same group keys out identically every call.
+  const repFor = (token) => {
+    const t = normaliseToken(token);
+    const set = graph.get(t);
+    if (!set) return t;
+    let min = null;
+    for (const x of set) if (min === null || x < min) min = x;
+    return min;
+  };
+
+  const groups = new Map();
+  for (const row of rows) {
+    const token = normaliseToken(`${row.catalog}${row.catalog_number}`);
+    const rep = repFor(token);
+    if (!groups.has(rep)) {
+      groups.set(rep, {
+        key: rep,
+        name: null,
+        ra_hours: null,
+        dec_degrees: null,
+        members: [],
+        designations: new Map(), // normalised token -> display string
+        lists: new Map(),        // slug -> name
+      });
+    }
+    const g = groups.get(rep);
+    const aliases = parseAliases(row.aliases);
+    g.members.push({
+      id: row.id,
+      catalog: row.catalog,
+      catalog_number: row.catalog_number,
+      name: row.name,
+      object_type: row.object_type,
+      ra_hours: row.ra_hours,
+      dec_degrees: row.dec_degrees,
+      magnitude: row.magnitude,
+      aliases,
+      list_slug: row.list_slug,
+      list_name: row.list_name,
+    });
+    g.designations.set(token, `${row.catalog} ${row.catalog_number}`);
+    for (const a of aliases) {
+      const at = normaliseToken(a);
+      if (at && !g.designations.has(at)) g.designations.set(at, a);
+    }
+    g.lists.set(row.list_slug, row.list_name);
+    if (!g.name && row.name) g.name = row.name;
+    if (g.ra_hours == null && row.ra_hours != null) {
+      g.ra_hours = row.ra_hours;
+      g.dec_degrees = row.dec_degrees;
+    }
+  }
+
+  const groupList = [...groups.values()].map((g) => ({
+    key: g.key,
+    name: g.name,
+    ra_hours: g.ra_hours,
+    dec_degrees: g.dec_degrees,
+    designations: [...g.designations.values()],
+    lists: [...g.lists.entries()].map(([slug, name]) => ({ slug, name })),
+    members: g.members,
+    multi: g.lists.size > 1 || g.designations.size > 1,
+  }));
+
+  // Suggestions: distinct located groups whose representative coords sit
+  // within `tol` degrees. O(n²) over ~500 groups is trivial and runs once
+  // per page load.
+  const located = groupList.filter((g) => g.ra_hours != null && g.dec_degrees != null);
+  const suggestions = [];
+  for (let i = 0; i < located.length; i++) {
+    for (let j = i + 1; j < located.length; j++) {
+      const a = located[i];
+      const b = located[j];
+      const sep = angularSepDeg(a.ra_hours, a.dec_degrees, b.ra_hours, b.dec_degrees);
+      if (sep <= tol) {
+        suggestions.push({
+          separation_arcmin: Math.round(sep * 600) / 10,
+          a: { key: a.key, name: a.name, designations: a.designations, ids: a.members.map((m) => m.id) },
+          b: { key: b.key, name: b.name, designations: b.designations, ids: b.members.map((m) => m.id) },
+        });
+      }
+    }
+  }
+  suggestions.sort((x, y) => x.separation_arcmin - y.separation_arcmin);
+
+  groupList.sort((a, b) => {
+    if (a.multi !== b.multi) return a.multi ? -1 : 1;
+    return String(a.name || a.key).localeCompare(String(b.name || b.key));
+  });
+
+  res.json({
+    tol,
+    counts: {
+      targets: groupList.length,
+      multi: groupList.filter((g) => g.multi).length,
+      entries: rows.length,
+      suggestions: suggestions.length,
+    },
+    groups: groupList,
+    suggestions: suggestions.slice(0, 200),
+  });
+});
+
+// Link two-or-more catalog entries as the same physical target by adding each
+// one's primary designation to the others' alias lists. The alias graph
+// computes transitive closure on read, so connecting A→B where B already
+// aliases C pulls C into the group too. Applies to future uploads; existing
+// completions aren't rewritten.
+app.post('/api/admin/crossref/link', basicAuth, (req, res) => {
+  const ids = Array.isArray(req.body?.ids)
+    ? req.body.ids.map(Number).filter(Number.isFinite)
+    : [];
+  const unique = [...new Set(ids)];
+  if (unique.length < 2) {
+    return res.status(400).json({ error: 'Provide at least two object ids to link' });
+  }
+  const placeholders = unique.map(() => '?').join(',');
+  const objs = db
+    .prepare(
+      `SELECT id, catalog, catalog_number, aliases FROM list_objects WHERE id IN (${placeholders})`,
+    )
+    .all(...unique);
+  if (objs.length !== unique.length) {
+    return res.status(404).json({ error: 'One or more objects not found' });
+  }
+
+  const tokenOf = (o) => normaliseToken(`${o.catalog}${o.catalog_number}`);
+  const allTokens = objs.map(tokenOf);
+  const update = db.prepare('UPDATE list_objects SET aliases = ? WHERE id = ?');
+  const updated = [];
+  const tx = db.transaction(() => {
+    for (const o of objs) {
+      const self = tokenOf(o);
+      const merged = new Set(parseAliases(o.aliases).map(normaliseToken).filter(Boolean));
+      for (const t of allTokens) if (t && t !== self) merged.add(t);
+      const arr = [...merged];
+      update.run(arr.length ? JSON.stringify(arr) : null, o.id);
+      updated.push({ id: o.id, aliases: arr });
+    }
+  });
+  tx();
+
+  res.json({ linked: unique, updated });
+});
+
 app.post('/api/admin/stage', basicAuth, stageUpload.single('image'), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No image uploaded' });
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -697,6 +697,68 @@ test('smoke', async (t) => {
     });
   });
 
+  await t.test('catalog cross-reference groups multi-name targets', async () => {
+    const norm = (s) => String(s).replace(/\s+/g, '').toUpperCase();
+    const xref = await fetchJsonAuthed('/api/admin/crossref');
+    assert.ok(Array.isArray(xref.groups), 'groups is an array');
+    assert.ok(Array.isArray(xref.suggestions), 'suggestions is an array');
+    for (const key of ['targets', 'multi', 'entries', 'suggestions']) {
+      assert.equal(typeof xref.counts[key], 'number', `counts.${key} numeric`);
+    }
+
+    // M42 is named M42 (Messier), NGC1976 (via Sh2-275 / MWWF aliases) and
+    // sits in more than one list — it should land in a single grouped target.
+    const orion = xref.groups.find((g) => {
+      const tokens = new Set(g.designations.map(norm));
+      return tokens.has('M42') && tokens.has('NGC1976');
+    });
+    assert.ok(orion, 'M42 and NGC1976 share a cross-reference group');
+    assert.ok(orion.multi, 'Orion group flagged multi-name');
+    const slugs = new Set(orion.members.map((m) => m.list_slug));
+    assert.ok(slugs.size >= 2, `Orion group spans >=2 lists, got ${slugs.size}`);
+  });
+
+  await t.test('cross-reference link joins two entries and rejects singletons', async () => {
+    const auth = { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') };
+    const messier = await fetchJsonAuthed('/api/lists/messier');
+    const m1 = messier.objects.find((o) => o.catalog_number === '1');
+    const m2 = messier.objects.find((o) => o.catalog_number === '2');
+    assert.ok(m1 && m2);
+
+    // Fewer than two ids is a 400.
+    const bad = await fetch(`${baseUrl}/api/admin/crossref/link`, {
+      method: 'POST', headers: { ...auth, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [m1.id] }),
+    });
+    assert.equal(bad.status, 400);
+
+    const res = await fetch(`${baseUrl}/api/admin/crossref/link`, {
+      method: 'POST', headers: { ...auth, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [m1.id, m2.id] }),
+    });
+    assert.equal(res.status, 200);
+    const out = await res.json();
+    const byId = Object.fromEntries(out.updated.map((u) => [u.id, u.aliases]));
+    assert.ok(byId[m1.id].includes('M2'), 'M1 now aliases M2');
+    assert.ok(byId[m2.id].includes('M1'), 'M2 now aliases M1');
+
+    // They now share a cross-reference group.
+    const xref = await fetchJsonAuthed('/api/admin/crossref');
+    const joined = xref.groups.find((g) => {
+      const ids = new Set(g.members.map((m) => m.id));
+      return ids.has(m1.id) && ids.has(m2.id);
+    });
+    assert.ok(joined, 'M1 and M2 grouped after linking');
+
+    // Restore so later assertions aren't surprised.
+    for (const id of [m1.id, m2.id]) {
+      await fetch(`${baseUrl}/api/admin/objects/${id}`, {
+        method: 'PATCH', headers: { ...auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ aliases: [] }),
+      });
+    }
+  });
+
   await t.test('dark-moon iCalendar feed has VEVENTs over the next year', async () => {
     const res = await fetch(`${baseUrl}/api/calendar/dark-moon.ics`);
     assert.equal(res.status, 200);


### PR DESCRIPTION
## Why

Some targets carry many catalog names — M42 is also NGC 1976, Sh2-275 and MWWF-12; 47 Tucanae is C106, NGC 104 and GC 1. You asked for a way to look through and match all the catalog names per target. This adds that as an admin page.

## What

New **`/admin/crossref.html`** (nav link + dashboard button):

- **Grouped targets** — collapses all 531 catalog entries into the ~328 physical targets they describe, by walking the connected components of the existing alias graph (`buildAliasGraph`). Each card shows the target's name, every designation it goes by (as chips), and which lists carry it. Filter by name/designation; toggle "only multi-name targets" (191 of them).
- **Possible unlinked matches** — entries that sit within a tunable arc-minute radius of each other but aren't alias-linked (e.g. C60/C61, both the Antennae Galaxies, 1.9′ apart). Each has a one-click **Link as same target** button.

New endpoints (both behind Basic Auth):
- `GET /api/admin/crossref?tol=<deg>` — returns grouped targets + coordinate-proximity suggestions + counts.
- `POST /api/admin/crossref/link` `{ ids: [...] }` — adds each entry's primary designation to the others' alias lists. The alias graph computes transitive closure on read, so linking A→B where B already aliases C pulls C in too. Applies to future uploads; existing completions aren't rewritten.

## Notes

- Reuses the same alias/normalisation machinery (`normaliseToken`, `parseAliases`, `buildAliasGraph`) that already powers cross-list completion, so grouping here matches exactly which lists an upload ticks.
- Default match radius is 6′ — tight enough to keep genuinely-distinct close pairs (M42/M43 ≈ 8′) separate, loose enough to catch catalog coordinate drift. Tunable in the UI.

## Test plan

- [x] `npm test` — 36/36 green, including two new cases: multi-name grouping (asserts M42 + NGC1976 land together across ≥2 lists) and the link round-trip (joins M1+M2, verifies aliases + regrouping, 400 on a single id).
- [x] Live boot sanity check: 531 entries → 328 targets, 191 multi-name, 1 suggestion (C60/C61 Antennae). No server errors.
- [ ] Manual: open `/admin/crossref.html`, filter, toggle multi-only, adjust radius, click a suggestion's Link button and confirm the pair merges.

https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_