### PR TITLE
Sortable table headers across every screen

### DIFF
--- a/admin/dashboard.js
+++ b/admin/dashboard.js
@@ -1,3 +1,5 @@
+import { catalogSortKey } from '/js/common.js';
+
 const STAT_ORDER = [
   ['observations', 'Observations'],
   ['photos', 'Photos'],
@@ -91,13 +93,15 @@ function renderRecent(rows) {
       ? el('a', { href: `/admin/object.html?id=${r.object_list_id}`, text: objectId })
       : document.createTextNode(objectId);
 
+    const observed = r.observed_at || r.created_at || '';
+    const observedMs = observed ? Date.parse(observed) : NaN;
     tbody.appendChild(el('tr', {},
       el('td', {}, thumb),
-      el('td', {}, idCell),
+      el('td', { 'data-sort': catalogSortKey(r.catalog, r.catalog_number) }, idCell),
       el('td', { text: r.title || r.object_name || '—' }),
       el('td', { text: r.telescope || '—' }),
-      el('td', { text: r.observed_at || r.created_at || '—' }),
-      el('td', { class: 'rating-cell', text: stars }),
+      el('td', { 'data-sort': Number.isFinite(observedMs) ? String(observedMs) : '', text: observed || '—' }),
+      el('td', { class: 'rating-cell', 'data-sort': r.rating != null ? String(r.rating) : '', text: stars }),
     ));
   }
 }
@@ -111,7 +115,7 @@ function renderTelescopes(telescopes) {
   }
   // Render as a small table — chips lost too much info now that the
   // rollup carries nights / frames / integration-hours / avg rating.
-  const tbl = el('table', { style: 'width:auto; font-size:0.85rem;' });
+  const tbl = el('table', { 'data-sortable': '', style: 'width:auto; font-size:0.85rem;' });
   const head = el('thead', {}, el('tr', {},
     el('th', { text: 'Telescope' }),
     el('th', { text: 'Obs' }),
@@ -127,7 +131,7 @@ function renderTelescopes(telescopes) {
       el('td', { text: String(t.count) }),
       el('td', { text: t.nights != null ? String(t.nights) : '—' }),
       el('td', { text: t.frames != null ? String(t.frames) : '—' }),
-      el('td', { text: t.integration_hours != null ? `${t.integration_hours.toFixed(1)} h` : '—' }),
+      el('td', { 'data-sort': t.integration_hours != null ? String(t.integration_hours) : '', text: t.integration_hours != null ? `${t.integration_hours.toFixed(1)} h` : '—' }),
       el('td', { text: t.avg_rating != null ? Number(t.avg_rating).toFixed(2) : '—' }),
     ));
   }
@@ -236,8 +240,8 @@ async function loadBackups() {
     });
     tbody.appendChild(el('tr', {},
       el('td', { text: a.name }),
-      el('td', { class: 'dim', text: `${(a.size / 1024 / 1024).toFixed(1)} MB` }),
-      el('td', { class: 'dim', text: new Date(a.modified).toLocaleString() }),
+      el('td', { class: 'dim', 'data-sort': String(a.size), text: `${(a.size / 1024 / 1024).toFixed(1)} MB` }),
+      el('td', { class: 'dim', 'data-sort': String(Date.parse(a.modified) || 0), text: new Date(a.modified).toLocaleString() }),
       el('td', {}, restoreBtn),
     ));
   }

--- a/admin/equipment.html
+++ b/admin/equipment.html
@@ -53,14 +53,14 @@
 
       <section class="section">
         <div class="table-wrapper">
-          <table>
+          <table data-sortable>
             <thead>
               <tr>
                 <th>Kind</th>
                 <th>Name</th>
                 <th>Notes</th>
                 <th>Status</th>
-                <th>Actions</th>
+                <th data-nosort>Actions</th>
               </tr>
             </thead>
             <tbody id="rows"></tbody>
@@ -69,6 +69,7 @@
       </section>
     </main>
     <script type="module" src="/admin/equipment.js"></script>
+    <script type="module" src="/js/sortable.js"></script>
     <script type="module" src="/admin/version.js"></script>
     <script type="module" src="/js/site-name.js"></script>
   </body>

--- a/admin/index.html
+++ b/admin/index.html
@@ -60,7 +60,7 @@
       <section class="section">
         <h2>Recent uploads</h2>
         <div class="table-wrapper">
-          <table>
+          <table data-sortable>
             <thead>
               <tr>
                 <th></th>
@@ -118,14 +118,15 @@
           <span id="backup-status" class="dim"></span>
         </div>
         <div class="table-wrapper">
-          <table>
-            <thead><tr><th>Archive</th><th>Size</th><th>Modified</th><th>Actions</th></tr></thead>
+          <table data-sortable>
+            <thead><tr><th>Archive</th><th>Size</th><th>Modified</th><th data-nosort>Actions</th></tr></thead>
             <tbody id="backup-rows"></tbody>
           </table>
         </div>
       </section>
     </main>
     <script type="module" src="/admin/dashboard.js"></script>
+    <script type="module" src="/js/sortable.js"></script>
     <script type="module" src="/admin/version.js"></script>
     <script type="module" src="/js/site-name.js"></script>
   </body>

--- a/admin/observations.html
+++ b/admin/observations.html
@@ -47,7 +47,7 @@
       </div>
 
       <div class="table-wrapper">
-        <table>
+        <table data-sortable>
           <thead>
             <tr>
               <th></th>
@@ -57,7 +57,7 @@
               <th>Captured</th>
               <th>Capture</th>
               <th>Rating</th>
-              <th>Actions</th>
+              <th data-nosort>Actions</th>
             </tr>
           </thead>
           <tbody id="rows"></tbody>
@@ -65,6 +65,7 @@
       </div>
     </main>
     <script type="module" src="/admin/observations.js"></script>
+    <script type="module" src="/js/sortable.js"></script>
     <script type="module" src="/admin/version.js"></script>
     <script type="module" src="/js/site-name.js"></script>
   </body>

--- a/admin/observations.js
+++ b/admin/observations.js
@@ -1,4 +1,4 @@
-import { fetchJson, el } from '/js/common.js';
+import { fetchJson, el, catalogSortKey } from '/js/common.js';
 
 const queryInput = document.getElementById('filter-query');
 const telescopeSelect = document.getElementById('filter-telescope');
@@ -108,14 +108,20 @@ function renderRows() {
 
     const actions = el('div', { class: 'tile-actions' }, featureBtn, deleteBtn);
 
+    const captured = o.observed_at || o.created_at || '';
+    const capturedMs = captured ? Date.parse(captured) : NaN;
+    const captureSecs = (o.stack_count != null && o.exposure_seconds != null)
+      ? o.stack_count * o.exposure_seconds
+      : (o.exposure_seconds != null ? o.exposure_seconds : null);
+
     tbody.appendChild(el('tr', {},
       el('td', {}, thumb),
-      el('td', {}, objCell),
+      el('td', { 'data-sort': catalogSortKey(o.object_catalog || o.catalog, o.object_catalog_number || o.catalog_number) }, objCell),
       el('td', { text: o.title || '—' }),
       el('td', { text: o.telescope || '—' }),
-      el('td', { text: o.observed_at || o.created_at || '—' }),
-      el('td', { class: 'dim', text: captureSummary(o) }),
-      el('td', { class: 'rating-cell', text: stars(o.rating) }),
+      el('td', { 'data-sort': Number.isFinite(capturedMs) ? String(capturedMs) : '', text: captured || '—' }),
+      el('td', { class: 'dim', 'data-sort': captureSecs != null ? String(captureSecs) : '', text: captureSummary(o) }),
+      el('td', { class: 'rating-cell', 'data-sort': o.rating != null ? String(o.rating) : '', text: stars(o.rating) }),
       el('td', {}, actions),
     ));
   }

--- a/backlog.md
+++ b/backlog.md
@@ -88,6 +88,13 @@ Items prefixed with ✅ are shipped on `main`; the others are still open.
   tunable arc-minute radius as "possible matches" with a one-click link
   action that adds the missing aliases. Backed by `GET /api/admin/crossref`
   and `POST /api/admin/crossref/link`.
+- ✅ **Sortable table headers everywhere** — shared `makeTableSortable()`
+  helper in `common.js` + auto-init `js/sortable.js` make every data table
+  click-to-sort (list, tonight, seestar, admin observations / equipment /
+  dashboard recent-uploads / telescope-usage / backups). Numeric, date,
+  rating, size and catalog-id columns sort correctly via per-cell
+  `data-sort` keys; blanks sink to the bottom; planner keeps its existing
+  bespoke sorter.
 
 ## Future ideas
 

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -72,6 +72,108 @@ export function qs(name) {
   return new URLSearchParams(location.search).get(name);
 }
 
+// Build a sort key for a catalog designation so "M1, M2, M10" order by their
+// numeric part instead of lexically ("M1, M10, M2"). Groups by catalog first,
+// then by the leading number zero-padded, keeping any non-numeric suffix
+// ("275b"). Feed the result into a cell's data-sort attribute.
+export function catalogSortKey(catalog, number) {
+  const cat = String(catalog || '').toUpperCase();
+  const num = String(number ?? '');
+  const m = num.match(/^(\d+)(.*)$/);
+  const padded = m ? m[1].padStart(7, '0') + m[2] : num;
+  return `${cat} ${padded}`;
+}
+
+// Make a <table>'s header cells click-to-sort. Each header cell (skipping
+// empty ones and any marked data-nosort) becomes a toggle: first click sorts
+// ascending, second descending. A row's value for a column comes from that
+// <td>'s data-sort attribute when present, otherwise it's inferred from the
+// cell text — numeric when the text parses as a number (after stripping
+// °, %, × and commas), else a case-insensitive string. Blank/"—" cells and
+// ragged rows (colspan placeholders) always sink to the bottom. The active
+// sort is re-applied automatically when the page rebuilds the <tbody>.
+export function makeTableSortable(table) {
+  if (!table || table._sortableInit) return;
+  const headRow = table.tHead && table.tHead.rows[0];
+  const tbody = table.tBodies[0];
+  if (!headRow || !tbody) return;
+  table._sortableInit = true;
+
+  const ths = [...headRow.cells];
+  const colCount = ths.length;
+  let activeIndex = -1;
+  let dir = 'asc';
+
+  function valueOf(row, idx) {
+    if (row.cells.length !== colCount) return null; // placeholder / colspan row
+    const cell = row.cells[idx];
+    if (!cell) return null;
+    const ds = cell.getAttribute('data-sort');
+    if (ds != null) {
+      if (ds === '') return null;
+      const n = Number(ds);
+      return Number.isFinite(n) ? n : ds.toLowerCase();
+    }
+    const text = (cell.textContent || '').trim();
+    if (text === '' || text === '—') return null;
+    const cleaned = text.replace(/[,%°×]/g, '').replace(/\s+/g, '');
+    if (cleaned !== '' && Number.isFinite(Number(cleaned))) return Number(cleaned);
+    return text.toLowerCase();
+  }
+
+  const mo = new MutationObserver(() => {
+    if (activeIndex >= 0) applySort();
+  });
+
+  function applySort() {
+    const rows = [...tbody.rows];
+    if (rows.length >= 2) {
+      const factor = dir === 'asc' ? 1 : -1;
+      const decorated = rows.map((row, i) => ({ row, i, val: valueOf(row, activeIndex) }));
+      decorated.sort((a, b) => {
+        if (a.val == null && b.val == null) return a.i - b.i;
+        if (a.val == null) return 1;   // nulls sink regardless of direction
+        if (b.val == null) return -1;
+        if (a.val < b.val) return -1 * factor;
+        if (a.val > b.val) return 1 * factor;
+        return a.i - b.i;              // stable
+      });
+      // Reorder without retriggering our own observer.
+      mo.disconnect();
+      for (const d of decorated) tbody.appendChild(d.row);
+      mo.takeRecords();
+      mo.observe(tbody, { childList: true });
+    }
+    ths.forEach((th, i) => {
+      th.classList.remove('sort-asc', 'sort-desc');
+      if (i === activeIndex) {
+        th.classList.add(dir === 'asc' ? 'sort-asc' : 'sort-desc');
+        th.setAttribute('aria-sort', dir === 'asc' ? 'ascending' : 'descending');
+      } else {
+        th.removeAttribute('aria-sort');
+      }
+    });
+  }
+
+  ths.forEach((th, idx) => {
+    if (th.hasAttribute('data-nosort') || !th.textContent.trim()) return;
+    th.classList.add('sortable');
+    th.setAttribute('role', 'button');
+    th.setAttribute('tabindex', '0');
+    const trigger = () => {
+      if (activeIndex === idx) dir = dir === 'asc' ? 'desc' : 'asc';
+      else { activeIndex = idx; dir = 'asc'; }
+      applySort();
+    };
+    th.addEventListener('click', trigger);
+    th.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); trigger(); }
+    });
+  });
+
+  mo.observe(tbody, { childList: true });
+}
+
 // Star-Trek-flavoured stardate, using the popular post-2000 calendar formula:
 //   stardate = (year - 2000) * 1000 + day_of_year / days_in_year * 1000
 // Lands in the TNG-ish 26000s for 2026, climbs about 1000 per Earth year.

--- a/public/js/list.js
+++ b/public/js/list.js
@@ -1,4 +1,4 @@
-import { fetchJson, el, formatRA, formatDec, typeLabel, highlightNav, qs } from './common.js';
+import { fetchJson, el, formatRA, formatDec, typeLabel, highlightNav, qs, catalogSortKey } from './common.js';
 
 highlightNav('home');
 
@@ -77,12 +77,13 @@ function render() {
       'tr',
       { class: o.completed ? 'observed' : '' },
       el('td', {}, thumb),
-      el('td', {}, el('a', { href: `/object.html?id=${o.id}`, text: `${o.catalog}${o.catalog_number}` })),
+      el('td', { 'data-sort': catalogSortKey(o.catalog, o.catalog_number) },
+        el('a', { href: `/object.html?id=${o.id}`, text: `${o.catalog}${o.catalog_number}` })),
       el('td', { text: o.name || '—' }),
       el('td', { text: typeLabel(o.object_type) }),
       el('td', { text: o.constellation || '—' }),
-      el('td', { class: live ? 'dim' : '', text: live || formatRA(o.ra_hours) }),
-      el('td', { class: live ? 'dim' : '', text: live || formatDec(o.dec_degrees) }),
+      el('td', { class: live ? 'dim' : '', 'data-sort': live ? '' : String(o.ra_hours ?? ''), text: live || formatRA(o.ra_hours) }),
+      el('td', { class: live ? 'dim' : '', 'data-sort': live ? '' : String(o.dec_degrees ?? ''), text: live || formatDec(o.dec_degrees) }),
       el('td', { text: o.magnitude != null ? Number(o.magnitude).toFixed(1) : '—' }),
       attemptsCell,
     ));

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -1,4 +1,4 @@
-import { fetchJson, el, typeLabel, highlightNav } from './common.js';
+import { fetchJson, el, typeLabel, highlightNav, catalogSortKey } from './common.js';
 import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
 import { mountTypeFilter, typesToParam } from './type-filter.js';
 import { mountDurationPicker } from './seestar-durations.js';
@@ -165,9 +165,10 @@ async function load() {
     }
     const t = slot.target;
     rows.appendChild(el('tr', { class: t.observed ? 'observed' : '' },
-      el('td', { text: slotLabel }),
-      el('td', { text: dur }),
-      el('td', {}, el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
+      el('td', { 'data-sort': slot.slot_start ? String(Date.parse(slot.slot_start)) : '', text: slotLabel }),
+      el('td', { 'data-sort': slot.duration_minutes != null ? String(slot.duration_minutes) : '', text: dur }),
+      el('td', { 'data-sort': catalogSortKey(t.catalog, t.catalog_number) },
+        el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
       el('td', { text: t.name || '—' }),
       el('td', { text: typeLabel(t.object_type) }),
       el('td', { text: t.constellation || '—' }),

--- a/public/js/sortable.js
+++ b/public/js/sortable.js
@@ -1,0 +1,21 @@
+// Auto-enhance every table marked `data-sortable` with click-to-sort headers.
+// Drop this module onto any page with a table; it works for tables already in
+// the HTML and for tables that page scripts build later (the observer catches
+// them when they're appended). Each table is enhanced at most once.
+import { makeTableSortable } from './common.js';
+
+function enhance(root) {
+  if (!root || !root.querySelectorAll) return;
+  if (root.matches && root.matches('table[data-sortable]')) makeTableSortable(root);
+  for (const t of root.querySelectorAll('table[data-sortable]')) makeTableSortable(t);
+}
+
+enhance(document);
+
+new MutationObserver((records) => {
+  for (const rec of records) {
+    for (const node of rec.addedNodes) {
+      if (node.nodeType === 1) enhance(node);
+    }
+  }
+}).observe(document.body, { childList: true, subtree: true });

--- a/public/js/tonight.js
+++ b/public/js/tonight.js
@@ -1,4 +1,4 @@
-import { fetchJson, el, typeLabel, highlightNav } from './common.js';
+import { fetchJson, el, typeLabel, highlightNav, catalogSortKey } from './common.js';
 import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
 import { mountTypeFilter, typesToParam } from './type-filter.js';
 
@@ -85,13 +85,14 @@ async function load() {
 
   for (const t of data.targets) {
     rows.appendChild(el('tr', { class: t.observed ? 'observed' : '' },
-      el('td', {}, el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
+      el('td', { 'data-sort': catalogSortKey(t.catalog, t.catalog_number) },
+        el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
       el('td', { text: t.name || '—' }),
       el('td', { text: typeLabel(t.object_type) }),
       el('td', { text: t.constellation || '—' }),
       el('td', { text: t.magnitude != null ? t.magnitude.toFixed(1) : '—' }),
       el('td', { text: fmtDeg(t.altitude) }),
-      el('td', { text: `${fmtDeg(t.azimuth)} ${compass(t.azimuth)}` }),
+      el('td', { 'data-sort': t.azimuth != null ? String(t.azimuth) : '', text: `${fmtDeg(t.azimuth)} ${compass(t.azimuth)}` }),
       el('td', { class: 'dim', text: t.list_name }),
     ));
   }

--- a/public/list.html
+++ b/public/list.html
@@ -48,7 +48,7 @@
       </div>
 
       <div class="table-wrapper">
-        <table>
+        <table data-sortable>
           <thead>
             <tr>
               <th></th>
@@ -67,6 +67,7 @@
       </div>
     </main>
     <script type="module" src="/js/list.js"></script>
+    <script type="module" src="/js/sortable.js"></script>
     <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -76,7 +76,7 @@
       <div id="window-line" class="dim" style="margin-bottom: 0.75rem;"></div>
 
       <div class="table-wrapper">
-        <table>
+        <table data-sortable>
           <thead>
             <tr>
               <th>Slot</th>
@@ -97,6 +97,7 @@
       </div>
     </main>
     <script type="module" src="/js/seestar-plan.js"></script>
+    <script type="module" src="/js/sortable.js"></script>
     <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -282,11 +282,18 @@ thead th {
   letter-spacing: 0.14em;
 }
 
-/* Sortable header: clickable, with a small arrow when active. */
-thead th[data-sort] { cursor: pointer; user-select: none; }
-thead th[data-sort]:hover { background: var(--peach); }
-thead th[data-sort].sort-asc::after  { content: ' ▲'; font-size: 0.65em; }
-thead th[data-sort].sort-desc::after { content: ' ▼'; font-size: 0.65em; }
+/* Sortable header: clickable, with a small arrow when active. The
+   data-sort selector serves the planner's bespoke sorter; the .sortable
+   class is added by the shared makeTableSortable() helper on every other
+   table. */
+thead th[data-sort],
+thead th.sortable { cursor: pointer; user-select: none; }
+thead th[data-sort]:hover,
+thead th.sortable:hover { background: var(--peach); }
+thead th[data-sort].sort-asc::after,
+thead th.sortable.sort-asc::after  { content: ' ▲'; font-size: 0.65em; }
+thead th[data-sort].sort-desc::after,
+thead th.sortable.sort-desc::after { content: ' ▼'; font-size: 0.65em; }
 
 tbody tr:hover { background: #1a0f08; }
 tbody tr.observed { background: rgba(153, 204, 153, 0.12); }

--- a/public/tonight.html
+++ b/public/tonight.html
@@ -52,7 +52,7 @@
       <div id="moon-line" class="dim" style="margin-bottom: 0.75rem;"></div>
 
       <div class="table-wrapper">
-        <table>
+        <table data-sortable>
           <thead>
             <tr>
               <th>Object</th>
@@ -70,6 +70,7 @@
       </div>
     </main>
     <script type="module" src="/js/tonight.js"></script>
+    <script type="module" src="/js/sortable.js"></script>
     <script type="module" src="/js/site-name.js"></script>
   </body>
 </html>

--- a/test/sortable.test.js
+++ b/test/sortable.test.js
@@ -1,0 +1,150 @@
+// Unit test for the shared table-sort helper in public/js/common.js.
+//
+// common.js is browser ESM (loaded via <script type="module">), but the repo
+// is "type": "commonjs", so Node can't import it directly. Instead we read the
+// source, strip the `export` keywords, and run it in a vm context with a tiny
+// DOM shim — enough to exercise the real sort algorithm (numeric detection,
+// nulls sinking, data-sort precedence, direction toggle) without a browser or
+// any extra dependency.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadCommon() {
+  const src = fs
+    .readFileSync(path.resolve(__dirname, '..', 'public', 'js', 'common.js'), 'utf8')
+    .replace(/^export /gm, '');
+  // MutationObserver is the only global the helper touches at call time; a
+  // no-op shim is fine because the test drives sorting through the click
+  // handlers directly rather than through DOM mutations.
+  class MutationObserver {
+    observe() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  }
+  const context = { MutationObserver, Date, Number, Math, console };
+  vm.createContext(context);
+  vm.runInContext(src, context);
+  return context;
+}
+
+// --- minimal DOM shim ----------------------------------------------------
+
+class ClassList {
+  constructor() { this._s = new Set(); }
+  add(...c) { c.forEach((x) => this._s.add(x)); }
+  remove(...c) { c.forEach((x) => this._s.delete(x)); }
+  contains(c) { return this._s.has(c); }
+}
+class Cell {
+  constructor(text, attrs = {}) {
+    this.textContent = text;
+    this._attrs = { ...attrs };
+    this.classList = new ClassList();
+    this._listeners = {};
+  }
+  getAttribute(k) { return k in this._attrs ? this._attrs[k] : null; }
+  setAttribute(k, v) { this._attrs[k] = String(v); }
+  removeAttribute(k) { delete this._attrs[k]; }
+  hasAttribute(k) { return k in this._attrs; }
+  addEventListener(type, fn) { (this._listeners[type] ||= []).push(fn); }
+  dispatch(type, ev = {}) { (this._listeners[type] || []).forEach((fn) => fn(ev)); }
+}
+class Row { constructor(cells) { this.cells = cells; } }
+class TBody {
+  constructor(rows) { this._rows = rows; }
+  get rows() { return this._rows; }
+  appendChild(row) {
+    const i = this._rows.indexOf(row);
+    if (i >= 0) this._rows.splice(i, 1);
+    this._rows.push(row);
+  }
+}
+
+function makeTable(headers, rowDefs) {
+  const headerCells = headers.map((h) => new Cell(h));
+  const rows = rowDefs.map((cells) => new Row(
+    cells.map((c) => (Array.isArray(c) ? new Cell(c[0], c[1]) : new Cell(c))),
+  ));
+  const tbody = new TBody(rows);
+  return {
+    table: { tHead: { rows: [{ cells: headerCells }] }, tBodies: [tbody] },
+    headerCells,
+    tbody,
+  };
+}
+
+const order = (tbody, col = 0) => tbody.rows.map((r) => r.cells[col].textContent);
+
+test('catalogSortKey orders by catalog then numeric value', () => {
+  const { catalogSortKey } = loadCommon();
+  const ids = [['M', 1], ['M', 10], ['M', 2], ['M', 110], ['C', 9], ['Sh2', '275b'], ['Sh2', '275']];
+  const sorted = ids
+    .map(([c, n]) => [c + n, catalogSortKey(c, n)])
+    .sort((a, b) => (a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0))
+    .map((x) => x[0]);
+  assert.deepEqual(sorted, ['C9', 'M1', 'M2', 'M10', 'M110', 'Sh2275', 'Sh2275b']);
+});
+
+test('makeTableSortable sorts numeric column, nulls sink, direction toggles', () => {
+  const { makeTableSortable } = loadCommon();
+  const { table, headerCells, tbody } = makeTable(
+    ['Name', 'Mag'],
+    [
+      ['Beta', '8.0'],
+      ['alpha', '2.5'],
+      ['Gamma', '—'],   // null magnitude
+      ['delta', '12.0'],
+    ],
+  );
+  makeTableSortable(table);
+
+  // Ascending by Mag: 2.5, 8.0, 12.0, then the dash sinks to the bottom.
+  headerCells[1].dispatch('click');
+  assert.deepEqual(order(tbody, 1), ['2.5', '8.0', '12.0', '—']);
+  assert.ok(headerCells[1].classList.contains('sort-asc'));
+
+  // Second click flips to descending; the null still sinks to the bottom.
+  headerCells[1].dispatch('click');
+  assert.deepEqual(order(tbody, 1), ['12.0', '8.0', '2.5', '—']);
+  assert.ok(headerCells[1].classList.contains('sort-desc'));
+});
+
+test('makeTableSortable sorts text case-insensitively and honours data-sort', () => {
+  const { makeTableSortable } = loadCommon();
+  const { table, headerCells, tbody } = makeTable(
+    ['Object', 'Name'],
+    [
+      [['M10', { 'data-sort': 'M 0000010' }], 'Ten'],
+      [['M2', { 'data-sort': 'M 0000002' }], 'Two'],
+      [['M1', { 'data-sort': 'M 0000001' }], 'One'],
+    ],
+  );
+  makeTableSortable(table);
+
+  // data-sort drives the order even though the visible text would sort
+  // M1, M10, M2 lexically.
+  headerCells[0].dispatch('click');
+  assert.deepEqual(order(tbody, 0), ['M1', 'M2', 'M10']);
+
+  // Name column falls back to case-insensitive text sort.
+  headerCells[1].dispatch('click');
+  assert.deepEqual(order(tbody, 1), ['One', 'Ten', 'Two']);
+});
+
+test('makeTableSortable skips data-nosort and empty headers', () => {
+  const { makeTableSortable } = loadCommon();
+  const { table, headerCells } = makeTable(
+    ['', 'Name', 'Actions'],
+    [['x', 'b', 'edit'], ['y', 'a', 'edit']],
+  );
+  headerCells[2].setAttribute('data-nosort', '');
+  makeTableSortable(table);
+  // Empty header (col 0) and data-nosort header (col 2) are not enhanced.
+  assert.ok(!headerCells[0].classList.contains('sortable'));
+  assert.ok(headerCells[1].classList.contains('sortable'));
+  assert.ok(!headerCells[2].classList.contains('sortable'));
+});


### PR DESCRIPTION
## What

Makes table headers click-to-sort on every screen that has a data table.

A shared `makeTableSortable()` helper in `common.js` plus a tiny auto-init module (`js/sortable.js`) enhance any `<table data-sortable>` — including tables that page scripts build after load (caught via a MutationObserver). Click a header to sort ascending, click again for descending, with an arrow indicator reusing the planner's existing `sort-asc`/`sort-desc` styling.

**Sort values**: taken from each cell's `data-sort` attribute when present, otherwise inferred from the text — numeric when it parses as a number (after stripping °, %, ×, commas), else a case-insensitive string. Blank/"—" cells and ragged colspan rows always sink to the bottom. The active sort re-applies automatically when a page rebuilds its `<tbody>` (e.g. after filtering).

## Screens wired up

- **Public**: list, tonight, seestar
- **Admin**: observations, equipment, dashboard (recent uploads, telescope usage, backups)
- **Planner** already had its own bespoke sorter — left untouched.

Per-cell `data-sort` keys added so non-text columns sort correctly: dates (timestamp), ratings (number), capture/duration (minutes), file size (bytes), azimuth & RA/Dec (degrees), and catalog IDs via a new `catalogSortKey()` so **M1 < M2 < M10** instead of lexical M1, M10, M2. Thumbnail/Actions headers are marked `data-nosort`.

## Test plan

- [x] `npm test` — **40/40 green**, including a new `test/sortable.test.js` that loads the *real* helper via `node:vm` against a small DOM shim (no new deps) and covers numeric sort, null-sinking, direction toggle, `data-sort` precedence, and `data-nosort`/empty-header skipping.
- [x] `catalogSortKey` verified: `C9, M1, M2, M10, M110, Sh2275, Sh2275b`.
- [x] Live boot: `/js/sortable.js` serves 200; every page ships the `data-sortable` wiring; no server errors.
- [ ] Manual: click headers on each page, confirm sort + arrow + that filtering preserves the active sort.

https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_