### PR TITLE
Seestar planner: multi-scope fleets with a non-overlapping table per scope

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -88,6 +88,12 @@ Items prefixed with ✅ are shipped on `main`; the others are still open.
   tunable arc-minute radius as "possible matches" with a one-click link
   action that adds the missing aliases. Backed by `GET /api/admin/crossref`
   and `POST /api/admin/crossref/link`.
+- ✅ **Multi-scope Seestar planner** — declare how many of each model you
+  own (e.g. 1× S30, 2× S30 Pro) and get a separate, non-overlapping
+  schedule per scope for the night. Backend allocates most-restrictive cap
+  first (shared assigned-target set) so a deep S50 keeps the faint targets
+  only it can reach; `fleet=s30:1,s30pro:2` query param, with the single
+  `telescope` path kept for back-compat.
 - ✅ **Sortable table headers everywhere** — shared `makeTableSortable()`
   helper in `common.js` + auto-init `js/sortable.js` make every data table
   click-to-sort (list, tonight, seestar, admin observations / equipment /

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -10,7 +10,7 @@ mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   load();
 }).then((fn) => {
   getCatalogSelection = fn;
-  if (rows.children.length) load();
+  if (schedules.children.length) load();
 });
 const getTypeSelection = mountTypeFilter(document.getElementById('type-filter'), () => load());
 
@@ -19,12 +19,11 @@ mountDurationPicker(document.getElementById('duration-filter'), () => {
   load();
 }).then((fn) => {
   getDurationParam = fn;
-  if (rows.children.length) load();
+  if (schedules.children.length) load();
 });
 
 const dateInput = document.getElementById('date-input');
 const timeInput = document.getElementById('time-input');
-const telescopeInput = document.getElementById('telescope-input');
 const latInput = document.getElementById('lat-input');
 const lonInput = document.getElementById('lon-input');
 const minAltInput = document.getElementById('min-alt-input');
@@ -33,10 +32,32 @@ const includeObserved = document.getElementById('include-observed');
 const locateBtn = document.getElementById('locate-btn');
 const runBtn = document.getElementById('run-btn');
 const status = document.getElementById('status');
-const scopeLine = document.getElementById('scope-line');
 const moonLine = document.getElementById('moon-line');
 const windowLine = document.getElementById('window-line');
-const rows = document.getElementById('rows');
+const schedules = document.getElementById('schedules');
+
+// Per-model fleet counts. Keys match the SEESTAR_SCOPES keys on the server.
+const FLEET_MODELS = [
+  ['s50', 'count-s50'],
+  ['s30', 'count-s30'],
+  ['s30pro', 'count-s30pro'],
+  ['any', 'count-any'],
+];
+const countInputs = Object.fromEntries(
+  FLEET_MODELS.map(([key, id]) => [key, document.getElementById(id)]),
+);
+
+function readFleet() {
+  const out = {};
+  for (const [key] of FLEET_MODELS) {
+    const n = Math.max(0, Math.min(8, parseInt(countInputs[key].value, 10) || 0));
+    if (n > 0) out[key] = n;
+  }
+  return out;
+}
+function fleetToParam(fleet) {
+  return Object.entries(fleet).map(([k, n]) => `${k}:${n}`).join(',');
+}
 
 // Default date / time to "now" in the user's local timezone — same
 // pattern the regular planner uses so 11pm-local doesn't roll into
@@ -46,16 +67,25 @@ const pad = (n) => String(n).padStart(2, '0');
 const nowLocal = new Date();
 dateInput.value = `${nowLocal.getFullYear()}-${pad(nowLocal.getMonth() + 1)}-${pad(nowLocal.getDate())}`;
 timeInput.value = `${pad(nowLocal.getHours())}:${pad(nowLocal.getMinutes())}`;
+// Restore the saved fleet, falling back to a single "Any" scope so the page
+// behaves like the old single-scope planner on a first visit.
 try {
-  const storedScope = localStorage.getItem('deepskylog.seestar_scope') || 'any';
-  if ([...telescopeInput.options].some((o) => o.value === storedScope)) {
-    telescopeInput.value = storedScope;
+  const saved = JSON.parse(localStorage.getItem('deepskylog.seestar_fleet') || 'null');
+  if (saved && typeof saved === 'object') {
+    for (const [key] of FLEET_MODELS) {
+      if (Number.isFinite(Number(saved[key]))) countInputs[key].value = String(saved[key]);
+    }
+  } else {
+    countInputs.any.value = '1';
   }
-} catch {}
-telescopeInput.addEventListener('change', () => {
-  try { localStorage.setItem('deepskylog.seestar_scope', telescopeInput.value); } catch {}
-  load();
-});
+} catch { countInputs.any.value = '1'; }
+
+for (const [, id] of FLEET_MODELS) {
+  document.getElementById(id).addEventListener('change', () => {
+    try { localStorage.setItem('deepskylog.seestar_fleet', JSON.stringify(readFleet())); } catch {}
+    load();
+  });
+}
 dateInput.addEventListener('change', () => load());
 timeInput.addEventListener('change', () => load());
 
@@ -91,7 +121,7 @@ async function load() {
   localStorage.setItem(STORE_KEY, JSON.stringify({ lat, lon }));
 
   status.textContent = 'Planning…';
-  rows.innerHTML = '';
+  schedules.innerHTML = '';
   // Combine date + time as local — the resulting Date is the correct
   // UTC instant. Falls back to "now" if either input is empty (e.g.
   // user cleared the date and tapped Plan).
@@ -100,11 +130,14 @@ async function load() {
     const candidate = new Date(`${dateInput.value}T${timeInput.value}`);
     if (!Number.isNaN(candidate.getTime())) startISO = candidate.toISOString();
   }
+  // No scopes entered → plan a single "Any" scope so the page isn't blank.
+  const fleet = readFleet();
+  const fleetParam = Object.keys(fleet).length ? fleetToParam(fleet) : 'any:1';
   const params = new URLSearchParams({
     lat: String(lat), lon: String(lon),
     min_alt: String(minAlt), max_alt: String(maxAlt),
     start: startISO,
-    telescope: telescopeInput.value || 'any',
+    fleet: fleetParam,
   });
   if (includeObserved.checked) params.set('include_observed', '1');
   const catParam = selectionToParam(getCatalogSelection());
@@ -123,17 +156,6 @@ async function load() {
   }
 
   const moonPct = (data.moon.illumination * 100).toFixed(0);
-  // Scope summary: name + brief sweet-spot blurb + magnitude cap so
-  // the user knows which targets are being filtered out.
-  if (data.scope) {
-    const capBit = data.scope.max_magnitude != null
-      ? ` · cap ≤ mag ${data.scope.max_magnitude.toFixed(1)}`
-      : ' · no magnitude filter';
-    const notesBit = data.scope.notes ? ` · ${data.scope.notes}` : '';
-    scopeLine.textContent = `Scope: ${data.scope.name}${capBit}${notesBit}`;
-  } else {
-    scopeLine.textContent = '';
-  }
   moonLine.textContent = `Moon at start: ${data.moon.name} (${moonPct}% illuminated)`;
 
   const start = new Date(data.window.start);
@@ -143,42 +165,62 @@ async function load() {
     ? `Session: ${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} – ${end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} (sunrise ${sunrise.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })})`
     : `Session: ${start.toLocaleString()} → ${end.toLocaleString()} (sun never sets in this window)`;
 
-  const filled = data.slots.filter((s) => s.target).length;
-  status.textContent = `${filled} of ${data.slots.length} slot${data.slots.length === 1 ? '' : 's'} filled`;
+  const scopes = data.scopes || (data.scope ? [{ ...data.scope, label: data.scope.name, slots: data.slots }] : []);
+  const totalTargets = scopes.reduce((acc, s) => acc + s.slots.length, 0);
+  status.textContent = scopes.length > 1
+    ? `${scopes.length} scopes · ${totalTargets} targets scheduled · no overlap`
+    : `${totalTargets} target${totalTargets === 1 ? '' : 's'} scheduled`;
 
-  if (!data.slots.length) {
-    rows.appendChild(el('tr', {}, el('td', { colspan: '11' },
-      el('div', { class: 'empty-state', text: 'No imaging window — sunrise is within the next hour.' }))));
-    return;
+  for (const scope of scopes) schedules.appendChild(buildScheduleSection(scope));
+}
+
+function buildRow(slot) {
+  const slotLabel = `${fmtTime(slot.slot_start)} – ${fmtTime(slot.slot_end)}`;
+  const dur = slot.duration_minutes != null ? `${slot.duration_minutes} min` : '—';
+  const t = slot.target;
+  return el('tr', { class: t.observed ? 'observed' : '' },
+    el('td', { 'data-sort': slot.slot_start ? String(Date.parse(slot.slot_start)) : '', text: slotLabel }),
+    el('td', { 'data-sort': slot.duration_minutes != null ? String(slot.duration_minutes) : '', text: dur }),
+    el('td', { 'data-sort': catalogSortKey(t.catalog, t.catalog_number) },
+      el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
+    el('td', { text: t.name || '—' }),
+    el('td', { text: typeLabel(t.object_type) }),
+    el('td', { text: t.constellation || '—' }),
+    el('td', { text: t.magnitude != null ? Number(t.magnitude).toFixed(1) : '—' }),
+    el('td', { text: fmtDeg(t.altitude_at_start) }),
+    el('td', { text: fmtDeg(t.altitude_at_end) }),
+    el('td', { text: fmtDeg(t.azimuth_at_start) }),
+    el('td', { class: 'dim list-cell', text: t.list_name }),
+  );
+}
+
+const COLUMNS = ['Slot', 'Duration', 'Object', 'Name', 'Type', 'Constellation',
+  'Mag', 'Alt start', 'Alt end', 'Az start', 'List'];
+
+function buildScheduleSection(scope) {
+  const capBit = scope.max_magnitude != null
+    ? `cap ≤ mag ${scope.max_magnitude.toFixed(1)}`
+    : 'no magnitude filter';
+  const n = scope.slots.length;
+  const head = el('div', { class: 'schedule-head' },
+    el('h2', { text: scope.label || scope.name }),
+    el('span', { class: 'dim', text: `${capBit} · ${n} target${n === 1 ? '' : 's'}` }),
+  );
+  if (scope.notes) head.appendChild(el('div', { class: 'dim schedule-notes', text: scope.notes }));
+
+  const tbody = el('tbody');
+  if (!n) {
+    tbody.appendChild(el('tr', {}, el('td', { colspan: String(COLUMNS.length) },
+      el('div', { class: 'empty-state', text: 'No targets fit this scope in the session window.' }))));
+  } else {
+    for (const slot of scope.slots) tbody.appendChild(buildRow(slot));
   }
 
-  for (const slot of data.slots) {
-    const slotLabel = `${fmtTime(slot.slot_start)} – ${fmtTime(slot.slot_end)}`;
-    const dur = slot.duration_minutes != null ? `${slot.duration_minutes} min` : '—';
-    if (!slot.target) {
-      rows.appendChild(el('tr', { class: 'dim' },
-        el('td', { text: slotLabel }),
-        el('td', { text: dur }),
-        el('td', { colspan: '9', class: 'empty-state', text: 'No target in altitude range that hasn\'t been used yet.' }),
-      ));
-      continue;
-    }
-    const t = slot.target;
-    rows.appendChild(el('tr', { class: t.observed ? 'observed' : '' },
-      el('td', { 'data-sort': slot.slot_start ? String(Date.parse(slot.slot_start)) : '', text: slotLabel }),
-      el('td', { 'data-sort': slot.duration_minutes != null ? String(slot.duration_minutes) : '', text: dur }),
-      el('td', { 'data-sort': catalogSortKey(t.catalog, t.catalog_number) },
-        el('a', { href: `/object.html?id=${t.id}`, text: `${t.catalog}${t.catalog_number}` })),
-      el('td', { text: t.name || '—' }),
-      el('td', { text: typeLabel(t.object_type) }),
-      el('td', { text: t.constellation || '—' }),
-      el('td', { text: t.magnitude != null ? Number(t.magnitude).toFixed(1) : '—' }),
-      el('td', { text: fmtDeg(t.altitude_at_start) }),
-      el('td', { text: fmtDeg(t.altitude_at_end) }),
-      el('td', { text: fmtDeg(t.azimuth_at_start) }),
-      el('td', { class: 'dim list-cell', text: t.list_name }),
-    ));
-  }
+  const table = el('table', { 'data-sortable': '' },
+    el('thead', {}, el('tr', {}, ...COLUMNS.map((c) => el('th', { text: c })))),
+    tbody,
+  );
+  return el('section', { class: 'schedule' }, head, el('div', { class: 'table-wrapper' }, table));
 }
 
 locateBtn.addEventListener('click', () => {

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -5,6 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>DeepSkyLog &mdash; Seestar Planner</title>
     <link rel="stylesheet" href="/styles.css" />
+    <style>
+      .fleet-control {
+        display: inline-flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+        border: 1px solid var(--accent); border-radius: var(--pill);
+        padding: 0.25rem 0.7rem;
+      }
+      .fleet-label {
+        font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.12em;
+        color: var(--peach); font-weight: 700;
+      }
+      .fleet-item { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.85rem; }
+      .fleet-item input { width: 3.4rem; }
+      .schedule { margin-bottom: 1.5rem; }
+      .schedule-head {
+        display: flex; align-items: baseline; gap: 0.6rem; flex-wrap: wrap;
+        margin-bottom: 0.4rem;
+      }
+      .schedule-head h2 { margin: 0; }
+      .schedule-notes { flex-basis: 100%; font-size: 0.82rem; }
+    </style>
   </head>
   <body>
     <header class="site-header">
@@ -24,7 +44,7 @@
     </header>
     <main>
       <h1 class="page-title">Seestar session planner</h1>
-      <p class="page-subtitle" id="subtitle">Targets allocated by per-type imaging duration, running from now until an hour before sunrise. Each pick is above your minimum altitude at the slot start and stays under the zenith-avoidance ceiling by the slot end.</p>
+      <p class="page-subtitle" id="subtitle">Say how many of each Seestar you own and get a separate, non-overlapping schedule per scope for the night. Targets are allocated by per-type imaging duration, running from now until an hour before sunrise — each pick is above your minimum altitude at the slot start and stays under the zenith-avoidance ceiling by the slot end. Fainter targets go to the deepest scope that can still reach them.</p>
 
       <div class="toolbar">
         <label>
@@ -35,15 +55,13 @@
           Time
           <input id="time-input" type="time" />
         </label>
-        <label>
-          Telescope
-          <select id="telescope-input">
-            <option value="any">Any</option>
-            <option value="s50">Seestar S50</option>
-            <option value="s30">Seestar S30</option>
-            <option value="s30pro">Seestar S30 Pro</option>
-          </select>
-        </label>
+        <span class="fleet-control">
+          <span class="fleet-label">Your scopes</span>
+          <label class="fleet-item">S50 <input id="count-s50" type="number" min="0" max="8" step="1" value="0" /></label>
+          <label class="fleet-item">S30 <input id="count-s30" type="number" min="0" max="8" step="1" value="0" /></label>
+          <label class="fleet-item">S30&nbsp;Pro <input id="count-s30pro" type="number" min="0" max="8" step="1" value="0" /></label>
+          <label class="fleet-item">Any <input id="count-any" type="number" min="0" max="8" step="1" value="0" /></label>
+        </span>
         <label>
           Latitude
           <input id="lat-input" type="number" step="any" placeholder="51.4769" />
@@ -71,30 +89,10 @@
         <span id="status" class="dim" style="margin-left:auto;"></span>
       </div>
 
-      <div id="scope-line" class="dim" style="margin-bottom: 0.25rem;"></div>
       <div id="moon-line" class="dim" style="margin-bottom: 0.25rem;"></div>
       <div id="window-line" class="dim" style="margin-bottom: 0.75rem;"></div>
 
-      <div class="table-wrapper">
-        <table data-sortable>
-          <thead>
-            <tr>
-              <th>Slot</th>
-              <th>Duration</th>
-              <th>Object</th>
-              <th>Name</th>
-              <th>Type</th>
-              <th>Constellation</th>
-              <th>Mag</th>
-              <th>Alt start</th>
-              <th>Alt end</th>
-              <th>Az start</th>
-              <th>List</th>
-            </tr>
-          </thead>
-          <tbody id="rows"></tbody>
-        </table>
-      </div>
+      <div id="schedules"></div>
     </main>
     <script type="module" src="/js/seestar-plan.js"></script>
     <script type="module" src="/js/sortable.js"></script>

--- a/server.js
+++ b/server.js
@@ -684,6 +684,23 @@ function parseSeestarScope(raw) {
   return SEESTAR_SCOPES[k] ? k : 'any';
 }
 
+// Parse a fleet spec like "s30:1,s30pro:2,s50:1" into per-model counts. Keys
+// are normalised the same way as parseSeestarScope; unknown keys and bad
+// counts are ignored. Total instances are capped at MAX_FLEET so a single
+// request can't ask the planner to schedule dozens of nights.
+const MAX_FLEET = 8;
+function parseFleet(raw) {
+  const counts = {};
+  for (const piece of String(raw || '').split(',')) {
+    const [kRaw, vRaw] = piece.split(':');
+    const key = parseSeestarScope(kRaw);
+    if (!kRaw || !SEESTAR_SCOPES[String(kRaw).toLowerCase().replace(/\s+/g, '')]) continue;
+    const n = Math.max(0, Math.min(MAX_FLEET, parseInt(vRaw, 10) || 0));
+    if (n > 0) counts[key] = (counts[key] || 0) + n;
+  }
+  return counts;
+}
+
 app.get('/api/seestar-planner', (req, res) => {
   const lat = Number(req.query.lat);
   const lon = Number(req.query.lon);
@@ -802,67 +819,123 @@ app.get('/api/seestar-planner', (req, res) => {
   // target's duration. If nothing fits at the current moment, advance by
   // 15 min and retry — covers the common "wait 15 minutes for the next
   // good target to clear 50°" case without spinning forever.
-  const assignedIds = new Set();
-  const plan = [];
-  let cursor = start.getTime();
-  let stalled = 0;
-  while (cursor < sessionEnd.getTime()) {
-    const slotStart = new Date(cursor);
-    let best = null;
-    for (const row of rows) {
-      if (!includeObserved && row.observed) continue;
-      if (assignedIds.has(row.id)) continue;
-      // Telescope cap: drop targets too faint for the chosen scope.
-      // NULL magnitudes (planets, ephemeris, free-form) always pass.
-      if (scope.max_magnitude != null
-          && row.magnitude != null
-          && Number(row.magnitude) > scope.max_magnitude) continue;
-      const dur = durationFor(row.object_type);
-      const slotEndMs = cursor + dur * 60_000;
-      if (slotEndMs > sessionEnd.getTime()) continue;
-      const slotEnd = new Date(slotEndMs);
-      const eqStart = coordsAt(row, slotStart);
-      const eqEnd = coordsAt(row, slotEnd);
-      if (!eqStart || !eqEnd) continue;
-      const posStart = altAz({ ...eqStart, lat, lon, date: slotStart });
-      const posEnd = altAz({ ...eqEnd, lat, lon, date: slotEnd });
-      if (!posStart || !posEnd) continue;
-      if (posStart.altitude < minAlt) continue;
-      if (posEnd.altitude > maxAlt) continue;
-      const score = -posStart.altitude * 1000 - (row.magnitude ?? 99);
-      if (!best || score > best.score) {
-        best = { row, posStart, posEnd, score, dur, slotEnd };
+  // Greedy variable-duration slot walk for ONE scope. Skips any target id
+  // already in `assignedIds` (shared across scopes so a fleet never
+  // double-books a target), respects the scope's magnitude cap, and marks
+  // each pick as assigned. Returns the scope's filled slots in time order.
+  function planForScope(scopeDef, assignedIds) {
+    const plan = [];
+    let cursor = start.getTime();
+    let stalled = 0;
+    while (cursor < sessionEnd.getTime()) {
+      const slotStart = new Date(cursor);
+      let best = null;
+      for (const row of rows) {
+        if (!includeObserved && row.observed) continue;
+        if (assignedIds.has(row.id)) continue;
+        // Telescope cap: drop targets too faint for the chosen scope.
+        // NULL magnitudes (planets, ephemeris, free-form) always pass.
+        if (scopeDef.max_magnitude != null
+            && row.magnitude != null
+            && Number(row.magnitude) > scopeDef.max_magnitude) continue;
+        const dur = durationFor(row.object_type);
+        const slotEndMs = cursor + dur * 60_000;
+        if (slotEndMs > sessionEnd.getTime()) continue;
+        const slotEnd = new Date(slotEndMs);
+        const eqStart = coordsAt(row, slotStart);
+        const eqEnd = coordsAt(row, slotEnd);
+        if (!eqStart || !eqEnd) continue;
+        const posStart = altAz({ ...eqStart, lat, lon, date: slotStart });
+        const posEnd = altAz({ ...eqEnd, lat, lon, date: slotEnd });
+        if (!posStart || !posEnd) continue;
+        if (posStart.altitude < minAlt) continue;
+        if (posEnd.altitude > maxAlt) continue;
+        const score = -posStart.altitude * 1000 - (row.magnitude ?? 99);
+        if (!best || score > best.score) {
+          best = { row, posStart, posEnd, score, dur, slotEnd };
+        }
+      }
+      if (!best) {
+        stalled += 1;
+        // Bail after an hour of stalled retries — no point looping forever.
+        if (stalled > 4) break;
+        cursor += 15 * 60_000;
+        continue;
+      }
+      stalled = 0;
+      assignedIds.add(best.row.id);
+      plan.push({
+        slot_start: slotStart.toISOString(),
+        slot_end: best.slotEnd.toISOString(),
+        duration_minutes: best.dur,
+        target: {
+          id: best.row.id,
+          catalog: best.row.catalog, catalog_number: best.row.catalog_number,
+          name: best.row.name, object_type: best.row.object_type,
+          constellation: best.row.constellation,
+          magnitude: best.row.magnitude,
+          list_slug: best.row.list_slug, list_name: best.row.list_name,
+          observed: !!best.row.observed,
+          altitude_at_start: best.posStart.altitude,
+          altitude_at_end: best.posEnd.altitude,
+          azimuth_at_start: best.posStart.azimuth,
+          azimuth_at_end: best.posEnd.azimuth,
+        },
+      });
+      cursor = best.slotEnd.getTime();
+    }
+    return plan;
+  }
+
+  // Build the list of scope instances. A `fleet` param ("s30:1,s30pro:2")
+  // means multi-scope: each physical scope gets its own non-overlapping
+  // schedule. Without it we fall back to the single `telescope` selection
+  // so older callers (and the existing tests) keep their shape.
+  const fleetCounts = parseFleet(req.query.fleet);
+  const modelOrder = Object.keys(SEESTAR_SCOPES); // any, s50, s30, s30pro
+  let instances = [];
+  if (Object.keys(fleetCounts).length) {
+    for (const key of modelOrder) {
+      const n = fleetCounts[key] || 0;
+      for (let i = 0; i < n; i++) {
+        instances.push({ key, model_index: i + 1, model_count: n });
       }
     }
-    if (!best) {
-      stalled += 1;
-      // Bail after an hour of stalled retries — no point looping forever.
-      if (stalled > 4) break;
-      cursor += 15 * 60_000;
-      continue;
-    }
-    stalled = 0;
-    assignedIds.add(best.row.id);
-    plan.push({
-      slot_start: slotStart.toISOString(),
-      slot_end: best.slotEnd.toISOString(),
-      duration_minutes: best.dur,
-      target: {
-        id: best.row.id,
-        catalog: best.row.catalog, catalog_number: best.row.catalog_number,
-        name: best.row.name, object_type: best.row.object_type,
-        constellation: best.row.constellation,
-        magnitude: best.row.magnitude,
-        list_slug: best.row.list_slug, list_name: best.row.list_name,
-        observed: !!best.row.observed,
-        altitude_at_start: best.posStart.altitude,
-        altitude_at_end: best.posEnd.altitude,
-        azimuth_at_start: best.posStart.azimuth,
-        azimuth_at_end: best.posEnd.azimuth,
-      },
-    });
-    cursor = best.slotEnd.getTime();
+  } else {
+    instances = [{ key: scopeKey, model_index: 1, model_count: 1 }];
   }
+
+  // Allocate most-restrictive scope first (lowest magnitude cap), so a deep
+  // scope (e.g. S50 ≤ 11) keeps the faint targets only it can reach instead
+  // of a shallower scope grabbing a target it can't even use. A null cap
+  // ("any") is the least restrictive, so it runs last. Stable for ties.
+  const capOf = (key) => SEESTAR_SCOPES[key].max_magnitude ?? Infinity;
+  const allocationOrder = instances
+    .map((inst, i) => ({ inst, i }))
+    .sort((a, b) => capOf(a.inst.key) - capOf(b.inst.key) || a.i - b.i)
+    .map((x) => x.inst);
+
+  const assignedIds = new Set();
+  for (const inst of allocationOrder) {
+    inst.slots = planForScope(SEESTAR_SCOPES[inst.key], assignedIds);
+  }
+
+  // Present scopes grouped by model (declaration order) then instance, which
+  // is friendlier than the internal allocation order.
+  const scopes = instances.map((inst) => {
+    const def = SEESTAR_SCOPES[inst.key];
+    const label = inst.model_count > 1 ? `${def.name} #${inst.model_index}` : def.name;
+    return {
+      key: inst.key,
+      name: def.name,
+      label,
+      max_magnitude: def.max_magnitude,
+      notes: def.notes || null,
+      instance_index: inst.model_index,
+      instance_count: inst.model_count,
+      slots: inst.slots || [],
+    };
+  });
 
   res.json({
     location: { lat, lon },
@@ -872,8 +945,10 @@ app.get('/api/seestar-planner', (req, res) => {
     max_altitude: maxAlt,
     moon: moonPhase(start),
     durations: { ...DEFAULT_DURATIONS, ...userDurations, _default: defaultDur },
-    scope: { key: scopeKey, ...scope },
-    slots: plan,
+    // Back-compat: single-scope callers still read `scope` + `slots`.
+    scope: { key: scopes[0].key, ...SEESTAR_SCOPES[scopes[0].key] },
+    slots: scopes[0].slots,
+    scopes,
   });
 });
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -930,6 +930,43 @@ test('smoke', async (t) => {
       'longer durations yield ≤ default slot count');
   });
 
+  await t.test('Seestar multi-scope fleet: one table per scope, no target overlap', async () => {
+    const start = new Date('2026-01-15T22:00:00Z').toISOString();
+    const data = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&min_alt=40&max_alt=85&fleet=s30:1,s30pro:2,s50:1`,
+    );
+    assert.ok(Array.isArray(data.scopes), 'scopes array present');
+    // 1 + 2 + 1 = 4 scope instances; duplicated models get #-suffixed labels.
+    assert.equal(data.scopes.length, 4);
+    const labels = data.scopes.map((s) => s.label);
+    assert.ok(labels.includes('Seestar S30 Pro #1'));
+    assert.ok(labels.includes('Seestar S30 Pro #2'));
+
+    // No target id appears in more than one scope's schedule.
+    const seen = new Set();
+    for (const scope of data.scopes) {
+      for (const slot of scope.slots) {
+        assert.ok(!seen.has(slot.target.id),
+          `target ${slot.target.id} double-booked across scopes`);
+        seen.add(slot.target.id);
+        // Each scope still respects its own magnitude cap.
+        if (scope.max_magnitude != null && slot.target.magnitude != null) {
+          assert.ok(slot.target.magnitude <= scope.max_magnitude,
+            `${scope.label} took mag ${slot.target.magnitude} over cap ${scope.max_magnitude}`);
+        }
+      }
+    }
+    assert.ok(seen.size > 0, 'at least some targets scheduled');
+
+    // Back-compat: a fleet-free call still returns scope + slots.
+    const single = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(start)}&telescope=s50`,
+    );
+    assert.equal(single.scope.key, 's50');
+    assert.ok(Array.isArray(single.slots));
+    assert.equal(single.scopes.length, 1);
+  });
+
   await t.test('NGC fallback resolves common designations', async () => {
     const res = await fetch(`${baseUrl}/api/admin/objects/lookup?q=NGC7000`, {
       headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },


### PR DESCRIPTION
## What

Makes the Seestar planner multi-scope. You declare how many of each model you own (e.g. **1× S30, 2× S30 Pro**) and get a **separate, non-overlapping schedule per physical scope** for the night — no target appears in two scopes' tables.

## How

**Backend** — the single-scope slot walk is extracted into `planForScope(scope, assignedIds)`. A new `fleet=s30:1,s30pro:2,s50:1` query param expands to one instance per scope, all drawing from a **shared assigned-target set** so a target is never double-booked. Scopes are allocated **most-restrictive magnitude cap first**, so a deep S50 (≤ mag 11) keeps the faint targets a shallower S30 (≤ mag 10) can't reach instead of a shallow scope grabbing them first. The old `telescope=` path plus the `scope` + `slots` response fields are kept for back-compat; a new `scopes[]` array carries the per-scope schedules.

**Frontend** — the Telescope dropdown becomes per-model count steppers (S50 / S30 / S30 Pro / Any), persisted in localStorage. One sortable table is rendered per scope, headed by the model label (`Seestar S30 Pro #1`, `#2` for duplicates), its magnitude cap and target count. Defaults to a single "Any" scope so a first visit behaves like the old planner.

## Example

`fleet=s30:1,s30pro:2,s50:1` at (51.5, 0) on a Jan night → 4 tables, 44 targets, **0 overlap**; S50 correctly claimed the mag-11 target only it can reach.

## Test plan

- [x] `npm test` — **41/41 green**, including a new test asserting 4 instances, `#`-suffixed labels for duplicate models, zero cross-scope target overlap, per-scope cap compliance, and that the fleet-free path still returns `scope` + `slots`.
- [x] Live boot: single-scope back-compat (`telescope=s30`) and multi-scope (`fleet=...`) both verified; `/seestar.html` + module serve 200, no server errors.
- [ ] Manual: set counts, confirm one table per scope, sortable headers, and that filters/durations still apply.

https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_