### PR TITLE
Seestar planner: dusk start (sunset + 30 min) and S30 Pro-only Milky Way wide-field

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -93,7 +93,9 @@ Items prefixed with ✅ are shipped on `main`; the others are still open.
   schedule per scope for the night. Backend allocates most-restrictive cap
   first (shared assigned-target set) so a deep S50 keeps the faint targets
   only it can reach; `fleet=s30:1,s30pro:2` query param, with the single
-  `telescope` path kept for back-compat.
+  `telescope` path kept for back-compat. Sessions auto-start 30 minutes
+  after sunset for the location (never before the requested start), and
+  Milky Way wide-field (MWWF) mosaics are scheduled only on the S30 Pro.
 - ✅ **Sortable table headers everywhere** — shared `makeTableSortable()`
   helper in `common.js` + auto-init `js/sortable.js` make every data table
   click-to-sort (list, tonight, seestar, admin observations / equipment /

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -158,12 +158,19 @@ async function load() {
   const moonPct = (data.moon.illumination * 100).toFixed(0);
   moonLine.textContent = `Moon at start: ${data.moon.name} (${moonPct}% illuminated)`;
 
+  const hm = (d) => d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   const start = new Date(data.window.start);
   const end = new Date(data.window.end);
   const sunrise = data.sunrise ? new Date(data.sunrise) : null;
-  windowLine.textContent = sunrise
-    ? `Session: ${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} – ${end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} (sunrise ${sunrise.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })})`
-    : `Session: ${start.toLocaleString()} → ${end.toLocaleString()} (sun never sets in this window)`;
+  const sunset = data.sunset ? new Date(data.sunset) : null;
+  if (sunrise) {
+    const sunsetBit = sunset ? `sunset ${hm(sunset)} · ` : '';
+    windowLine.textContent =
+      `Session: ${hm(start)} – ${hm(end)} · ${sunsetBit}starts 30 min after sunset · sunrise ${hm(sunrise)}`;
+  } else {
+    windowLine.textContent =
+      `Session: ${start.toLocaleString()} → ${end.toLocaleString()} (sun never sets in this window)`;
+  }
 
   const scopes = data.scopes || (data.scope ? [{ ...data.scope, label: data.scope.name, slots: data.slots }] : []);
   const totalTargets = scopes.reduce((acc, s) => acc + s.slots.length, 0);

--- a/public/seestar.html
+++ b/public/seestar.html
@@ -44,7 +44,7 @@
     </header>
     <main>
       <h1 class="page-title">Seestar session planner</h1>
-      <p class="page-subtitle" id="subtitle">Say how many of each Seestar you own and get a separate, non-overlapping schedule per scope for the night. Targets are allocated by per-type imaging duration, running from now until an hour before sunrise — each pick is above your minimum altitude at the slot start and stays under the zenith-avoidance ceiling by the slot end. Fainter targets go to the deepest scope that can still reach them.</p>
+      <p class="page-subtitle" id="subtitle">Say how many of each Seestar you own and get a separate, non-overlapping schedule per scope for the night. Sessions begin 30 minutes after sunset and run until an hour before sunrise; targets are allocated by per-type imaging duration, each above your minimum altitude at the slot start and under the zenith-avoidance ceiling by the slot end. Fainter targets go to the deepest scope that can still reach them, and Milky Way wide-field mosaics are scheduled only on the S30 Pro.</p>
 
       <div class="toolbar">
         <label>

--- a/server.js
+++ b/server.js
@@ -744,9 +744,41 @@ app.get('/api/seestar-planner', (req, res) => {
     }
     prev = cur;
   }
+  // Find the sunset that opens this night — the most recent time the sun
+  // dropped below the horizon before that sunrise. Walk backward from
+  // sunrise hour-by-hour: going back in time the sun is below the horizon
+  // (night) until, at sunset, it was above. Refine to the nearest minute.
+  let sunset = null;
+  if (sunrise) {
+    let later = sunAltAt(new Date(sunrise.getTime() - 60_000)); // just pre-sunrise: night
+    for (let h = 1; h <= 36; h++) {
+      const t = new Date(sunrise.getTime() - h * 3_600_000);
+      const cur = sunAltAt(t);
+      if (cur >= 0 && later < 0) {
+        let lo = t;                                  // daytime (alt ≥ 0)
+        let hi = new Date(t.getTime() + 3_600_000);  // night (alt < 0)
+        for (let i = 0; i < 60; i++) {
+          const mid = new Date((lo.getTime() + hi.getTime()) / 2);
+          if (sunAltAt(mid) >= 0) lo = mid; else hi = mid;
+        }
+        sunset = hi;
+        break;
+      }
+      later = cur;
+    }
+  }
+
+  // Sessions begin 30 minutes after sunset so the sky has darkened, but
+  // never before the caller's requested start (so planning at 1 a.m. starts
+  // from 1 a.m., not back at dusk).
+  const duskStart = sunset ? new Date(sunset.getTime() + 30 * 60_000) : null;
+  const sessionStart = duskStart && duskStart.getTime() > start.getTime()
+    ? duskStart
+    : start;
+
   const sessionEnd = sunrise
     ? new Date(sunrise.getTime() - 3_600_000)
-    : new Date(start.getTime() + 12 * 3_600_000);
+    : new Date(sessionStart.getTime() + 12 * 3_600_000);
 
   // Per-object-type recommended imaging durations (minutes). The defaults
   // are based on Seestar community conventions for f/4-5 smart-scope
@@ -823,9 +855,16 @@ app.get('/api/seestar-planner', (req, res) => {
   // already in `assignedIds` (shared across scopes so a fleet never
   // double-books a target), respects the scope's magnitude cap, and marks
   // each pick as assigned. Returns the scope's filled slots in time order.
+  // Milky Way wide-field mosaics (the MWWF / milky-way-wide list) need the
+  // S30 Pro's sensor + EAF — no other Seestar frames them well, so only the
+  // S30 Pro is allowed to pick them up.
+  const isWideField = (row) =>
+    row.catalog === 'MWWF' || row.list_slug === 'milky-way-wide';
+
   function planForScope(scopeDef, assignedIds) {
+    const wideFieldOK = scopeDef === SEESTAR_SCOPES.s30pro;
     const plan = [];
-    let cursor = start.getTime();
+    let cursor = sessionStart.getTime();
     let stalled = 0;
     while (cursor < sessionEnd.getTime()) {
       const slotStart = new Date(cursor);
@@ -833,6 +872,8 @@ app.get('/api/seestar-planner', (req, res) => {
       for (const row of rows) {
         if (!includeObserved && row.observed) continue;
         if (assignedIds.has(row.id)) continue;
+        // Wide-field Milky Way mosaics are S30 Pro only.
+        if (!wideFieldOK && isWideField(row)) continue;
         // Telescope cap: drop targets too faint for the chosen scope.
         // NULL magnitudes (planets, ephemeris, free-form) always pass.
         if (scopeDef.max_magnitude != null
@@ -939,11 +980,13 @@ app.get('/api/seestar-planner', (req, res) => {
 
   res.json({
     location: { lat, lon },
-    window: { start: start.toISOString(), end: sessionEnd.toISOString() },
+    window: { start: sessionStart.toISOString(), end: sessionEnd.toISOString() },
+    requested_start: start.toISOString(),
+    sunset: sunset ? sunset.toISOString() : null,
     sunrise: sunrise ? sunrise.toISOString() : null,
     min_altitude: minAlt,
     max_altitude: maxAlt,
-    moon: moonPhase(start),
+    moon: moonPhase(sessionStart),
     durations: { ...DEFAULT_DURATIONS, ...userDurations, _default: defaultDur },
     // Back-compat: single-scope callers still read `scope` + `slots`.
     scope: { key: scopes[0].key, ...SEESTAR_SCOPES[scopes[0].key] },

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -967,6 +967,42 @@ test('smoke', async (t) => {
     assert.equal(single.scopes.length, 1);
   });
 
+  await t.test('Seestar session starts 30 min after sunset', async () => {
+    // Request a daytime start; the planner should push the session start to
+    // exactly 30 minutes after that evening's sunset.
+    const day = new Date('2026-01-15T12:00:00Z').toISOString();
+    const data = await fetchJsonAuthed(
+      `/api/seestar-planner?lat=51.5&lon=0&start=${encodeURIComponent(day)}&min_alt=20&max_alt=85`,
+    );
+    assert.ok(data.sunset, 'sunset computed');
+    assert.ok(data.sunrise, 'sunrise computed');
+    const sunset = new Date(data.sunset).getTime();
+    const winStart = new Date(data.window.start).getTime();
+    assert.equal(winStart - sunset, 30 * 60_000, 'window starts 30 min after sunset');
+    // The dusk start is later than the (daytime) requested start.
+    assert.ok(winStart > new Date(data.requested_start).getTime());
+  });
+
+  await t.test('Milky Way wide-field targets are S30 Pro only', async () => {
+    const start = new Date('2026-07-15T20:00:00Z').toISOString();
+    const q = (scope) =>
+      `/api/seestar-planner?lat=40&lon=-100&start=${encodeURIComponent(start)}`
+      + `&min_alt=15&max_alt=89&include_observed=1&lists=milky-way-wide&fleet=${scope}:1`;
+
+    const pro = await fetchJsonAuthed(q('s30pro'));
+    const proSlots = pro.scopes[0].slots;
+    assert.ok(proSlots.length > 0, 'S30 Pro schedules wide-field targets');
+    for (const s of proSlots) {
+      assert.equal(s.target.catalog, 'MWWF', 'S30 Pro slot is a wide-field target');
+    }
+
+    for (const scope of ['s30', 's50', 'any']) {
+      const other = await fetchJsonAuthed(q(scope));
+      assert.equal(other.scopes[0].slots.length, 0,
+        `${scope} must not schedule wide-field MWWF targets`);
+    }
+  });
+
   await t.test('NGC fallback resolves common designations', async () => {
     const res = await fetch(`${baseUrl}/api/admin/objects/lookup?q=NGC7000`, {
       headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },


### PR DESCRIPTION
## What

Two refinements to the Seestar session planner.

### 1. Sessions start 30 minutes after sunset

The planner now finds the sunset that opens the night (scanning backward from the computed sunrise, refined to the minute) and sets the session start to **sunset + 30 min** for the selected location — but never earlier than the caller's requested start, so planning at 1 a.m. still starts at 1 a.m. rather than rewinding to dusk. The response gains `sunset` and `requested_start`, and the window line now reads "sunset HH:MM · starts 30 min after sunset".

### 2. Milky Way wide-field is S30 Pro only

Only the S30 Pro can frame the wide-field Milky Way mosaics, so `planForScope` skips the MWWF / `milky-way-wide` rows for every other scope (S30, S50, Any).

## Verified

- Daytime request (12:00Z, London Jan) → sunset 16:13Z → **window.start 16:43Z** (exactly +30 min).
- `lists=milky-way-wide`: S30 Pro scheduled 9 MWWF targets; S30 / S50 / Any scheduled **0**.

## Test plan

- [x] `npm test` — **43/43 green**, including two new cases: `window.start == sunset + 30 min` for a daytime request, and MWWF list yields slots only for an S30 Pro fleet (zero for the others).
- [x] Existing variable-duration test still passes (a 22:00 start is already past dusk, so it's unaffected).

https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_