### PR TITLE
Bulk plate solve on the admin observations page

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -255,6 +255,19 @@ fieldset.sidecar legend {
 }
 .edit-btn:hover { background: var(--peach); }
 
+/* Plate-solve status pill on the Solve column. The success state links to
+   the atlas so a click takes you to the rendered tile; pending/solving are
+   inert badges; idle / failure render as the standard .edit-btn above. */
+.solve-pill {
+  display: inline-block; font-size: 0.74rem; padding: 0.22rem 0.65rem;
+  border-radius: var(--pill); text-transform: uppercase; letter-spacing: 0.12em;
+  font-weight: 700; font-family: var(--condensed); text-decoration: none;
+}
+.solve-pill.solved { background: var(--success); color: #000; }
+.solve-pill.solved:hover { background: var(--peach); }
+.solve-pill.pending { background: var(--warn); color: #000; }
+.solve-btn:disabled { opacity: 0.6; cursor: wait; }
+
 /* ---------- Modal ---------- */
 
 .modal-overlay {

--- a/admin/observations.html
+++ b/admin/observations.html
@@ -30,8 +30,13 @@
         </div>
         <div class="dash-actions">
           <a class="button-link" href="/admin/upload.html">+ New observation</a>
+          <button type="button" class="button-link ghost-link" id="bulk-solve-btn"
+                  title="Submit every unsolved observation with an image to astrometry.net">
+            Bulk plate solve
+          </button>
           <a class="button-link ghost-link" href="/api/observations.csv">Download CSV</a>
         </div>
+        <div id="bulk-solve-status" class="dim" style="flex-basis: 100%; margin-top: 0.35rem;"></div>
       </div>
 
       <div class="toolbar">
@@ -57,6 +62,7 @@
               <th>Captured</th>
               <th>Capture</th>
               <th>Rating</th>
+              <th>Solve</th>
               <th data-nosort>Actions</th>
             </tr>
           </thead>

--- a/admin/observations.js
+++ b/admin/observations.js
@@ -46,6 +46,47 @@ async function featureRow(id, button) {
   }
 }
 
+async function solveRow(id, button) {
+  button.disabled = true;
+  button.textContent = 'Queuing…';
+  try {
+    const res = await fetch(`/api/admin/observations/${id}/platesolve`, { method: 'POST' });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || `HTTP ${res.status}`);
+    }
+    button.textContent = 'Queued';
+    await loadRows();
+  } catch (err) {
+    button.disabled = false;
+    button.textContent = 'Solve';
+    alert(`Solve failed: ${err.message}`);
+  }
+}
+
+// One-shot status pill for the Solve column. "Solved" links to the atlas
+// where solved frames are rendered on the sky sphere; pending/solving are
+// inert; idle / failure / "no image" show a button that fires the existing
+// per-observation solve endpoint.
+function solveCell(o) {
+  if (!o.image_path) {
+    return el('span', { class: 'dim', text: 'no image' });
+  }
+  if (o.solver_status === 'success') {
+    return el('a', {
+      class: 'solve-pill solved',
+      href: '/atlas.html', title: 'View on sky atlas',
+      text: 'Solved',
+    });
+  }
+  if (o.solver_status === 'pending' || o.solver_status === 'solving') {
+    return el('span', { class: 'solve-pill pending', text: o.solver_status });
+  }
+  const btn = el('button', { type: 'button', class: 'edit-btn solve-btn', text: 'Solve' });
+  btn.addEventListener('click', () => solveRow(o.id, btn));
+  return btn;
+}
+
 function objectLabel(o) {
   if (o.object_catalog && o.object_catalog_number) {
     return `${o.object_catalog}${o.object_catalog_number}${o.object_name ? ' · ' + o.object_name : ''}`;
@@ -75,7 +116,7 @@ function renderRows() {
   countEl.textContent = `${visible.length} of ${state.rows.length} observation${state.rows.length === 1 ? '' : 's'}`;
 
   if (!visible.length) {
-    tbody.appendChild(el('tr', {}, el('td', { colspan: '8' },
+    tbody.appendChild(el('tr', {}, el('td', { colspan: '9' },
       el('div', { class: 'empty-state', text: state.rows.length
         ? 'No observations match the current filters.'
         : 'No observations logged yet — drop an image on the Upload page.' }))));
@@ -122,6 +163,7 @@ function renderRows() {
       el('td', { 'data-sort': Number.isFinite(capturedMs) ? String(capturedMs) : '', text: captured || '—' }),
       el('td', { class: 'dim', 'data-sort': captureSecs != null ? String(captureSecs) : '', text: captureSummary(o) }),
       el('td', { class: 'rating-cell', 'data-sort': o.rating != null ? String(o.rating) : '', text: stars(o.rating) }),
+      el('td', { 'data-sort': o.solver_status || '' }, solveCell(o)),
       el('td', {}, actions),
     ));
   }
@@ -139,11 +181,60 @@ async function loadRows() {
   try {
     state.rows = await fetchJson('/api/observations');
     renderRows();
+    updateBulkButton();
   } catch (err) {
     tbody.innerHTML = '';
-    tbody.appendChild(el('tr', {}, el('td', { colspan: '8', class: 'muted', text: `Failed to load: ${err.message}` })));
+    tbody.appendChild(el('tr', {}, el('td', { colspan: '9', class: 'muted', text: `Failed to load: ${err.message}` })));
   }
 }
+
+const bulkBtn = document.getElementById('bulk-solve-btn');
+const bulkStatus = document.getElementById('bulk-solve-status');
+
+function unsolvedCount() {
+  return state.rows.filter((o) =>
+    o.image_path
+    && o.solver_status !== 'success'
+    && o.solver_status !== 'pending'
+    && o.solver_status !== 'solving'
+  ).length;
+}
+
+function updateBulkButton() {
+  if (!bulkBtn) return;
+  const n = unsolvedCount();
+  bulkBtn.textContent = n > 0 ? `Bulk plate solve (${n})` : 'Bulk plate solve';
+  bulkBtn.disabled = n === 0;
+}
+
+bulkBtn?.addEventListener('click', async () => {
+  const n = unsolvedCount();
+  if (!n) return;
+  if (!confirm(
+    `Submit ${n} unsolved image${n === 1 ? '' : 's'} to astrometry.net?\n\n`
+    + `Up to 50 will be queued. Solves are processed in Nova's free queue and take`
+    + ` minutes to land — refresh this page later to see results.`,
+  )) return;
+  bulkBtn.disabled = true;
+  bulkStatus.textContent = `Submitting ${n}…`;
+  try {
+    const res = await fetch('/api/admin/observations/bulk-platesolve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    const bits = [`${data.queued} queued`];
+    if (data.skipped) bits.push(`${data.skipped} skipped`);
+    if (data.errors) bits.push(`${data.errors} error${data.errors === 1 ? '' : 's'}`);
+    bulkStatus.textContent = `${bits.join(' · ')}. Solve results land in a few minutes.`;
+    await loadRows();
+  } catch (err) {
+    bulkStatus.textContent = `Bulk solve failed: ${err.message}`;
+    bulkBtn.disabled = false;
+  }
+});
 
 queryInput.addEventListener('input', () => {
   state.filter.q = queryInput.value;

--- a/backlog.md
+++ b/backlog.md
@@ -88,6 +88,12 @@ Items prefixed with ✅ are shipped on `main`; the others are still open.
   tunable arc-minute radius as "possible matches" with a one-click link
   action that adds the missing aliases. Backed by `GET /api/admin/crossref`
   and `POST /api/admin/crossref/link`.
+- ✅ **Bulk plate solve on admin observations** — a "Bulk plate solve (N)"
+  button submits up to 50 unsolved-with-image observations to astrometry.net
+  in one click, plus a per-row Solve column with Solved/pending/Solve pill.
+  Backed by `POST /api/admin/observations/bulk-platesolve` (single
+  astrometry session, sequential uploads to stay polite to Nova's free
+  queue; supports an optional `ids[]` payload).
 - ✅ **Multi-scope Seestar planner** — declare how many of each model you
   own (e.g. 1× S30, 2× S30 Pro) and get a separate, non-overlapping
   schedule per scope for the night. Backend allocates most-restrictive cap

--- a/server.js
+++ b/server.js
@@ -1836,6 +1836,89 @@ function setSolverStatus(observationId, fields) {
     .run({ ...fields, id: observationId });
 }
 
+// Bulk-submit a batch of observations to astrometry.net. The caller can pass
+// an explicit `ids` array (e.g. checkboxes on the admin observations page),
+// or omit it to queue every observation that has an image and isn't already
+// solved / pending. Observations are submitted sequentially using a single
+// astrometry session — Nova's free queue is happier with serial uploads than
+// a burst, and a 503 from no API key short-circuits the whole batch.
+app.post('/api/admin/observations/bulk-platesolve', basicAuth, async (req, res) => {
+  const requestedIds = Array.isArray(req.body?.ids)
+    ? req.body.ids.map(Number).filter(Number.isFinite)
+    : null;
+
+  // Eligible = has an image, isn't already solved, isn't currently queued.
+  // For an explicit ids list we still surface skips so the UI can report
+  // them; for the "all unsolved" path we just pull them from SQL.
+  const eligibleClause = `image_path IS NOT NULL
+     AND (solver_status IS NULL OR solver_status IN ('idle', 'failure'))`;
+  let candidates;
+  if (requestedIds && requestedIds.length) {
+    const placeholders = requestedIds.map(() => '?').join(',');
+    candidates = db
+      .prepare(
+        `SELECT id, image_path, solver_status FROM observations
+           WHERE id IN (${placeholders})`,
+      )
+      .all(...requestedIds);
+  } else {
+    candidates = db
+      .prepare(`SELECT id, image_path, solver_status FROM observations
+                  WHERE ${eligibleClause}
+                  ORDER BY id DESC LIMIT 50`)
+      .all();
+  }
+
+  let session;
+  try { session = await astrometry.login(); }
+  catch (err) {
+    if (err.code === 'no_key') {
+      return res.status(503).json({ error: 'ASTROMETRY_API_KEY is not set on the server' });
+    }
+    return res.status(502).json({ error: `astrometry login failed: ${err.message}` });
+  }
+
+  const results = [];
+  for (const obs of candidates) {
+    if (!obs.image_path) {
+      results.push({ id: obs.id, status: 'skipped', reason: 'no image' });
+      continue;
+    }
+    if (obs.solver_status === 'success') {
+      results.push({ id: obs.id, status: 'skipped', reason: 'already solved' });
+      continue;
+    }
+    if (obs.solver_status === 'pending' || obs.solver_status === 'solving') {
+      results.push({ id: obs.id, status: 'skipped', reason: `already ${obs.solver_status}` });
+      continue;
+    }
+    const full = path.resolve(UPLOAD_DIR, obs.image_path);
+    if (!full.startsWith(UPLOAD_DIR + path.sep) || !fs.existsSync(full)) {
+      results.push({ id: obs.id, status: 'error', reason: 'image file not found' });
+      continue;
+    }
+    try {
+      const subid = await astrometry.submitFile(session, full);
+      setSolverStatus(obs.id, {
+        solver_status: 'pending',
+        solver_job_id: String(subid),
+      });
+      results.push({ id: obs.id, status: 'queued', subid: String(subid) });
+    } catch (err) {
+      results.push({ id: obs.id, status: 'error', reason: err.message });
+    }
+  }
+
+  const queued = results.filter((r) => r.status === 'queued').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+  const errors = results.filter((r) => r.status === 'error').length;
+  res.status(202).json({
+    queued, skipped, errors,
+    considered: results.length,
+    results,
+  });
+});
+
 app.post('/api/admin/observations/:id/platesolve', basicAuth, async (req, res) => {
   const id = Number(req.params.id);
   if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1003,6 +1003,34 @@ test('smoke', async (t) => {
     }
   });
 
+  await t.test('bulk plate-solve endpoint: auth + payload contract', async () => {
+    const auth = { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') };
+
+    // Unauthed call → 401.
+    const noAuth = await fetch(`${baseUrl}/api/admin/observations/bulk-platesolve`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+    });
+    assert.equal(noAuth.status, 401);
+
+    // Authed but no ASTROMETRY_API_KEY set in the CI env → 503 with a clear
+    // error. This pins the endpoint's plumbing without hitting the network.
+    const res = await fetch(`${baseUrl}/api/admin/observations/bulk-platesolve`, {
+      method: 'POST', headers: { ...auth, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.match(body.error, /ASTROMETRY_API_KEY/);
+
+    // Explicit ids array path still produces the same auth/short-circuit
+    // shape — confirms the request body is parsed and not 400'd.
+    const withIds = await fetch(`${baseUrl}/api/admin/observations/bulk-platesolve`, {
+      method: 'POST', headers: { ...auth, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [1, 2, 3] }),
+    });
+    assert.equal(withIds.status, 503);
+  });
+
   await t.test('NGC fallback resolves common designations', async () => {
     const res = await fetch(`${baseUrl}/api/admin/objects/lookup?q=NGC7000`, {
       headers: { Authorization: 'Basic ' + Buffer.from(`admin:${PASSWORD}`).toString('base64') },


### PR DESCRIPTION
## What

A one-click way to plate-solve every observation that isn't solved yet, from the admin observations page.

- **"Bulk plate solve (N)" button** in the page header — submits up to 50 unsolved-with-image observations to astrometry.net at once. N is the live unsolved count; the button disables when N=0.
- **New Solve column** on each row:
  - **Solved** — green pill linking through to `/atlas.html`
  - **pending / solving** — amber pill, inert
  - **Solve** — button that fires the existing per-row endpoint (idle / failure / never-tried)
  - **no image** — dim placeholder when there's nothing to solve

## How

`POST /api/admin/observations/bulk-platesolve` logs into astrometry once per batch (Nova's free queue prefers serial uploads to a burst), then iterates over either an explicit `{ ids: [...] }` payload or the auto-picked top-50 candidates (`image_path NOT NULL`, `solver_status NULL / idle / failure`), submits each file sequentially, and returns a per-id result with `queued / skipped / errors` counts. A missing `ASTROMETRY_API_KEY` short-circuits with a clean 503.

## Test plan

- [x] `npm test` — **44/44 green**, including a new case that pins the bulk endpoint's auth (401 without creds → 503 once authed without an API key) and confirms the explicit-ids path is parsed without a 400.
- [x] Live boot: page wiring serves (HTML contains `bulk-solve-btn`, new Solve column, `solveCell`/`solveRow` in JS, `solve-pill`/`solve-btn` in CSS); endpoint returns the expected 503 shape without an API key.
- [ ] Manual with a real `ASTROMETRY_API_KEY`: click Bulk plate solve, confirm row pills flip to `pending`, refresh later, see them go green / red.

https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_