### PR TITLE
Seestar planner: stop duplicating scope tables when load() races

### DIFF
--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -105,7 +105,15 @@ function fmtTime(iso) {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
+// Generation token used to discard stale fetch responses. Multiple load()s
+// can run concurrently (auto-load on init + filter-mount Promises resolving
+// + count change events all fire one each); without this, each call's
+// post-fetch append would stack on top of earlier calls' appends, producing
+// duplicate schedule sections.
+let loadGen = 0;
+
 async function load() {
+  const myGen = ++loadGen;
   const lat = Number(latInput.value);
   const lon = Number(lonInput.value);
   const minAlt = Number(minAltInput.value);
@@ -151,9 +159,19 @@ async function load() {
   try {
     data = await fetchJson(`/api/seestar-planner?${params}`);
   } catch (err) {
+    if (myGen !== loadGen) return;
     status.textContent = `Failed: ${err.message}`;
     return;
   }
+
+  // Newer load() superseded us — let it do the painting.
+  if (myGen !== loadGen) return;
+
+  // Clear once more, in case an earlier (now-superseded) load() resolved
+  // and appended before us. Belt-and-braces: the gen check above already
+  // covers it, but this keeps the DOM authoritative even if a future edit
+  // reintroduces the race.
+  schedules.innerHTML = '';
 
   const moonPct = (data.moon.illumination * 100).toFixed(0);
   moonLine.textContent = `Moon at start: ${data.moon.name} (${moonPct}% illuminated)`;


### PR DESCRIPTION
## Bug

Your screenshot shows three schedule sections — **S50, S30 Pro, S50 again** — even though only two scopes were selected. The second S50 table is a duplicate, with the same 8 targets as the first.

## Why

`load()` is fired from several places that can run near-concurrently:

- the lat/lon auto-load at module bottom
- the catalog and duration filter Promises resolving (both guarded by `schedules.children.length` but the guard fires late under some timing)
- direct user input on the count steppers

Each in-flight `load()` clears `schedules` **before** awaiting the fetch, then appends sections **after**. If two loads overlap: both clear (to empty), both fetch, both append — and the later append stacks on top of the earlier one. Hence the duplicated `Seestar S50 · 8 targets` section.

## Fix

A generation token. Each `load()` bumps `loadGen` and captures its own `myGen` at entry; after the await, if `loadGen` has moved on (a newer `load()` superseded us), we return without painting. The latest call always wins, the earlier ones drop out silently. Belt-and-braces: also clear `schedules` once more after the gen check, so a future regression to the gen logic would still self-correct.

## Test plan

- [x] `npm test` — **44/44 green** (no behavioral change at the API layer).
- [x] Live boot: `seestar-plan.js` serves 200 with the fix present (`loadGen`, `myGen !== loadGen`).
- [ ] Manual: open `/seestar.html`, set 1× S50 + 1× S30 Pro, confirm exactly two tables.

https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YarLzZfzpYvFBGyU9kwoCT)_