### PR TITLE
Full-codebase audit: 30+ bug fixes and UX hardening

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -46,8 +46,6 @@
   font: inherit;
   cursor: pointer;
   text-decoration: underline;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 
 .linkish:hover { color: var(--peach); }

--- a/admin/object.js
+++ b/admin/object.js
@@ -318,10 +318,16 @@ function toLocalDt(s) {
 function openEditModal(o) {
   const overlay = el('div', { class: 'modal-overlay' });
   const card = el('div', { class: 'modal' });
+  // step: 'any' on number inputs — the default step=1 makes fractional
+  // stored values (EXIF sub-second exposures like 0.5) a stepMismatch
+  // that blocks the whole form from submitting.
   const fld = (label, name, type, value) =>
     el('label', { class: 'field' },
       el('span', { text: label }),
-      el('input', { type, name, value: value == null ? '' : String(value) }),
+      el('input', {
+        type, name, value: value == null ? '' : String(value),
+        ...(type === 'number' ? { step: 'any' } : {}),
+      }),
     );
   const fldArea = (label, name, value) => {
     const ta = el('textarea', { name, rows: '3' });

--- a/admin/observations.js
+++ b/admin/observations.js
@@ -141,13 +141,18 @@ function renderRows() {
         })
       : document.createTextNode(objectLabel(o));
 
-    const featureBtn = el('button', { type: 'button', class: 'feature-btn', text: '★' , title: 'Make featured' });
-    featureBtn.addEventListener('click', () => featureRow(o.id, featureBtn));
+    // Featuring works per catalog id — the server 400s on rows without
+    // one, so don't offer the button for free-form observations.
+    const canFeature = o.catalog && o.catalog_number;
+    const featureBtn = canFeature
+      ? el('button', { type: 'button', class: 'feature-btn', text: '★', title: 'Make featured' })
+      : null;
+    if (featureBtn) featureBtn.addEventListener('click', () => featureRow(o.id, featureBtn));
 
     const deleteBtn = el('button', { type: 'button', class: 'delete-btn', text: 'Delete' });
     deleteBtn.addEventListener('click', () => deleteRow(o.id, deleteBtn));
 
-    const actions = el('div', { class: 'tile-actions' }, featureBtn, deleteBtn);
+    const actions = el('div', { class: 'tile-actions' }, ...(featureBtn ? [featureBtn] : []), deleteBtn);
 
     const captured = o.observed_at || o.created_at || '';
     const capturedMs = captured ? Date.parse(captured) : NaN;

--- a/admin/upload.html
+++ b/admin/upload.html
@@ -28,7 +28,7 @@
 
       <section class="section">
         <div id="dropzone" class="dropzone" tabindex="0" role="button" aria-label="Upload image">
-          <input id="file-input" type="file" accept="image/*" hidden multiple />
+          <input id="file-input" type="file" accept="image/*,.fits,.fit,.json" hidden multiple />
           <div class="dropzone-inner">
             <div class="dropzone-icon" aria-hidden="true">◎</div>
             <p><strong>Drag &amp; drop</strong> images here</p>
@@ -101,6 +101,7 @@
                 <input id="dec-degrees-input" name="dec_degrees" type="number" step="any" min="-90" max="90" placeholder="e.g. -5.391" />
               </label>
               <small class="dim" style="flex-basis:100%;">Per-observation sky position. Useful for comets and other moving targets.</small>
+              <small id="coords-warning" style="flex-basis:100%; color:var(--peach);"></small>
             </div>
 
             <label class="field">

--- a/admin/upload.js
+++ b/admin/upload.js
@@ -85,6 +85,8 @@ function updateMoonPreview() {
 
 const objectCache = new Map();
 let currentStage = null;
+let pendingSidecar = null;           // sidecar dropped with an image, applied once staged
+let urlPreselect = null;             // ?object_id= preselect, re-applied after resets
 let objectSearchSeq = 0;
 const stageQueue = [];               // staged items waiting for review/save
 const queuePanel = document.getElementById('queue-panel');
@@ -177,7 +179,10 @@ dropzone.addEventListener('keydown', (e) => {
 ['dragleave', 'drop'].forEach((ev) =>
   dropzone.addEventListener(ev, (e) => {
     e.preventDefault(); e.stopPropagation();
-    if (ev === 'dragleave' && e.target !== dropzone) return;
+    // dragleave usually bubbles from .dropzone-inner when the cursor exits
+    // the zone — only ignore it when the pointer moved to another element
+    // still inside the dropzone, or the highlight sticks forever.
+    if (ev === 'dragleave' && e.relatedTarget && dropzone.contains(e.relatedTarget)) return;
     dropzone.classList.remove('drag');
   }),
 );
@@ -256,9 +261,15 @@ async function handleFiles(files) {
     setStatus('Drop an image, a FITS file, a Seestar .json, or any combination.', 'error');
     return;
   }
-  // Sidecar JSON applies to whatever's currently active — apply it first so
-  // the form has its values before the first stage finishes.
-  if (json) applySidecar(json);
+  // A sidecar dropped alongside an image belongs to that image: hold it
+  // and let onStaged() apply it after the stage activates. Applying it
+  // immediately raced the upload — setActiveStage → resetPerImageFields
+  // wiped every sidecar-filled value seconds later. A sidecar dropped on
+  // its own still applies to whatever's currently active.
+  if (json) {
+    if (captures.length) pendingSidecar = json;
+    else applySidecar(json);
+  }
   // Stage one at a time. Slower than the old parallel fan-out, but it's the
   // only pattern that works reliably with iOS multi-pick. setStatus errors
   // are surfaced individually instead of silently swallowed.
@@ -370,6 +381,9 @@ function resetPerImageFields() {
   stackCountInput.value = '';
   filterInput.value = '';
   seestarJsonField.value = '';
+  // Also clear the sidecar file input — a stale filename in the picker
+  // means re-selecting the same file fires no change event.
+  sidecarInput.value = '';
   moonDisplay.value = '';
   objectInput.value = '';
   objectIdField.value = '';
@@ -379,6 +393,7 @@ function resetPerImageFields() {
   raHoursInput.value = '';
   decDegreesInput.value = '';
   objectHint.textContent = '';
+  if (coordsWarning) coordsWarning.textContent = '';
 }
 
 async function onStaged(res) {
@@ -400,7 +415,10 @@ async function onStaged(res) {
     latitudeInput.value = res.exif.latitude.toFixed(6);
     longitudeInput.value = res.exif.longitude.toFixed(6);
     if (gpsHint) {
-      const source = res.guesses?.from_ocr ? 'watermark OCR' : 'image EXIF';
+      // coords_from_text means the coords were mined out of the watermark /
+      // EXIF text fields; from_ocr alone only says OCR ran, not that it
+      // produced the coordinates (real GPS tags may have).
+      const source = res.guesses?.coords_from_text ? 'watermark text' : 'image EXIF GPS';
       gpsHint.textContent = `Auto-filled from ${source} (${res.exif.latitude.toFixed(4)}, ${res.exif.longitude.toFixed(4)}).`;
     }
   } else if (defaultLatitude != null && defaultLongitude != null) {
@@ -428,8 +446,12 @@ async function onStaged(res) {
   if (res.telescope_match) {
     telescopeSelect.value = res.telescope_match;
     telescopeHint.textContent = `Auto-detected from ${metaSource}: ${res.exif.device || 'device'}`;
+  } else if (telescopeSelect.value) {
+    // Telescope is a shared-across-batch field — keep the user's manual
+    // pick when the next image carries no device info, instead of
+    // blanking it on every queue advance.
+    telescopeHint.textContent = `No device info in ${metaSource} — keeping “${telescopeSelect.value}”.`;
   } else {
-    telescopeSelect.value = '';
     telescopeHint.textContent = res.exif?.device
       ? `No automatic match for device “${res.exif.device}”. Please pick one.`
       : `No device info in ${metaSource}. Please pick a telescope.`;
@@ -448,6 +470,19 @@ async function onStaged(res) {
     await searchObjects(targetGuess);
     resolveObjectFromInput();
     if (!objectIdField.value) await tryNgcFallback();
+  } else if (!objectInput.value && urlPreselect) {
+    // "+ Log another attempt" navigated here with ?object_id= — restore
+    // that choice whenever the image itself carries no target guess
+    // (resetPerImageFields cleared the initial preselect on first drop).
+    applyPreselect(urlPreselect);
+  }
+
+  // Apply a sidecar that arrived in the same drop as this image, now that
+  // the per-image reset is behind us.
+  if (pendingSidecar) {
+    const sidecar = pendingSidecar;
+    pendingSidecar = null;
+    await applySidecar(sidecar);
   }
 
   // Sub-exposure (per frame): prefer the EXIF / filename value the server
@@ -495,9 +530,13 @@ async function onStaged(res) {
     exifSummary.append(dt, dd);
   }
 
+  updateCoordsWarning();
   formSection.hidden = false;
   formSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  setStatus('');
+  // Keep a just-saved confirmation visible while the next queued item
+  // loads — clearing unconditionally erased "Saved observation #N" the
+  // instant advanceQueue() activated the next chip.
+  if (!statusEl.classList.contains('success')) setStatus('');
 }
 
 async function searchObjects(q) {
@@ -589,6 +628,23 @@ async function tryNgcFallback() {
   if (hit.dec_degrees != null && !decDegreesInput.value) decDegreesInput.value = hit.dec_degrees.toFixed(4);
   objectHint.textContent = `${hit.source}: ${hit.name}${hit.constellation ? ' · ' + hit.constellation : ''}${hit.magnitude != null ? ' · mag ' + hit.magnitude : ''}`;
 }
+
+// Free-form observations (comets especially) only appear in the planners
+// when they carry RA/Dec — warn while the form is being filled instead of
+// letting the target silently vanish from /planner and /seestar.
+const coordsWarning = document.getElementById('coords-warning');
+function updateCoordsWarning() {
+  if (!coordsWarning) return;
+  const freeForm = !objectIdField.value && objectTypeInput.value;
+  const missingCoords = raHoursInput.value === '' || decDegreesInput.value === '';
+  coordsWarning.textContent = freeForm && missingCoords
+    ? 'No RA/Dec — this observation won\'t appear in the planners. Enter coordinates above to include it.'
+    : '';
+}
+[objectTypeInput, raHoursInput, decDegreesInput, objectInput].forEach((i) => {
+  i.addEventListener('input', updateCoordsWarning);
+  i.addEventListener('change', updateCoordsWarning);
+});
 
 let typingTimer = null;
 objectInput.addEventListener('input', () => {
@@ -704,9 +760,17 @@ async function maybeAutoFetchWeather() {
   lastAutoWeatherKey = key;
   await runWeatherFetch();
 }
+// Debounced: typing coordinates digit-by-digit produces a distinct
+// (date, lat, lon) tuple per keystroke, and Open-Meteo's free tier 429s
+// when hit that fast. Wait for the user to pause before fetching.
+let weatherDebounceTimer = null;
+function scheduleAutoWeather() {
+  clearTimeout(weatherDebounceTimer);
+  weatherDebounceTimer = setTimeout(maybeAutoFetchWeather, 750);
+}
 [dateInput, latitudeInput, longitudeInput].forEach((i) => {
-  i.addEventListener('input', maybeAutoFetchWeather);
-  i.addEventListener('change', maybeAutoFetchWeather);
+  i.addEventListener('input', scheduleAutoWeather);
+  i.addEventListener('change', scheduleAutoWeather);
 });
 [latitudeInput, longitudeInput].forEach((i) => {
   i.addEventListener('change', maybeAutoFillFromLocationHistory);
@@ -815,7 +879,13 @@ form.addEventListener('submit', async (e) => {
   e.preventDefault();
   if (!currentStage) return;
 
-  resolveObjectFromInput();
+  // Re-resolve only when the object input actually matches a seeded row.
+  // Running the full resolve unconditionally cleared catalog/number for
+  // any non-seeded value — wiping the NGC-fallback autofill and manually
+  // typed designations (comets) right before the payload was built.
+  if (objectCache.get(objectInput.value.trim().toLowerCase())) {
+    resolveObjectFromInput();
+  }
 
   const payload = {
     stage_id: stageIdField.value,
@@ -873,6 +943,26 @@ form.addEventListener('submit', async (e) => {
   }
 });
 
+function applyPreselect(obj) {
+  const label = `${obj.catalog}${obj.catalog_number}${obj.name ? ' — ' + obj.name : ''}`;
+  objectInput.value = label;
+  objectIdField.value = obj.id;
+  catalogInput.value = obj.catalog;
+  catalogNumberInput.value = obj.catalog_number;
+  objectHint.textContent = `${obj.list_name} · ${obj.object_type || ''} ${obj.constellation ? '· ' + obj.constellation : ''}`;
+  // Cache it so later autocomplete edits round-trip cleanly.
+  objectCache.set(label.toLowerCase(), {
+    id: obj.id,
+    catalog: obj.catalog,
+    catalog_number: obj.catalog_number,
+    name: obj.name,
+    object_type: obj.object_type,
+    constellation: obj.constellation,
+    list_name: obj.list_name,
+    list_slug: obj.list_slug,
+  });
+}
+
 async function preselectFromUrl() {
   const params = new URLSearchParams(location.search);
   const oid = params.get('object_id');
@@ -881,23 +971,8 @@ async function preselectFromUrl() {
     const res = await fetch(`/api/objects/${encodeURIComponent(oid)}`);
     if (!res.ok) return;
     const obj = await res.json();
-    const label = `${obj.catalog}${obj.catalog_number}${obj.name ? ' — ' + obj.name : ''}`;
-    objectInput.value = label;
-    objectIdField.value = obj.id;
-    catalogInput.value = obj.catalog;
-    catalogNumberInput.value = obj.catalog_number;
-    objectHint.textContent = `${obj.list_name} · ${obj.object_type || ''} ${obj.constellation ? '· ' + obj.constellation : ''}`;
-    // Cache it so later autocomplete edits round-trip cleanly.
-    objectCache.set(label.toLowerCase(), {
-      id: obj.id,
-      catalog: obj.catalog,
-      catalog_number: obj.catalog_number,
-      name: obj.name,
-      object_type: obj.object_type,
-      constellation: obj.constellation,
-      list_name: obj.list_name,
-      list_slug: obj.list_slug,
-    });
+    urlPreselect = obj;
+    applyPreselect(obj);
   } catch {}
 }
 

--- a/backlog.md
+++ b/backlog.md
@@ -263,13 +263,10 @@ expansions. Listed roughly by user-visible impact, not effort.
     digits) but a crafted POST `{rating:"abc"}` either errors out or
     stores NULL silently. Fix: `Number.isFinite(n) ? clampedValue
     : null`.
-49. **Seestar planner stalls bail after 1 h with no target.** The
-    walk-forward loop advances by 15 min when nothing fits and gives
-    up after 4 stalls in a row — fine for a sparse catalog filter on a
-    short night, but on a narrow `types=` selection it can end the
-    plan early instead of skipping over a dry hour and resuming when
-    something rises again. Better: keep stepping forward until
-    `sessionEnd`, only break on natural end.
+49. ✅ **Seestar planner stalls bail after 1 h with no target.** The
+    stall counter is gone; the walk now steps 15 min at a time all the
+    way to `sessionEnd`, so a dry hour mid-night no longer truncates
+    the rest of the plan.
 50. ✅ **OpenNGC alias collisions.** `lib/ngc.js` indexes both primary
     name and every Common-name alias in a single `Map`, so when two
     catalog entries share a common name (e.g. "Veil Nebula" maps to
@@ -280,12 +277,11 @@ expansions. Listed roughly by user-visible impact, not effort.
 
 ### Latent / security-adjacent
 
-51. **No CSRF protection on `/api/admin/*` write endpoints.** Basic-auth
-    is automatically attached by the browser, so any tab logged into
-    the admin can be tricked into POSTing a delete from a hostile
-    origin via `fetch(..., {credentials: 'include'})`. Fix: require
-    a same-origin header, a CSRF token, or switch admin to a session
-    cookie with `SameSite=Strict`.
+51. ✅ **No CSRF protection on `/api/admin/*` write endpoints.**
+    `basicAuth` now rejects non-GET requests whose `Origin` header host
+    doesn't match the request `Host` (403). Origin-less clients (curl,
+    scripts) still pass; browsers always send Origin on cross-site
+    fetch/XHR/form POSTs, which is the attack this blocks.
 52. ✅ **No rate-limit on successful admin writes.** The per-IP sliding
     window in `basicAuth` only counts failures; once authed, a bot
     with the password can spam observations. Add a token bucket on
@@ -301,45 +297,148 @@ expansions. Listed roughly by user-visible impact, not effort.
     correctly configured, the admin password leaks in clear text.
     Add a check at boot that warns when `TRUST_PROXY=1` is set
     without `https://` being visible in `X-Forwarded-Proto`.
-55. **Open-Meteo proxy hammers upstream on every keystroke.** The
-    upload form auto-fetches weather whenever `(date, lat, lon)`
-    changes. While the client de-dupes consecutive identical
-    tuples, fast typing of the GPS field triggers many distinct
-    tuples in flight. Open-Meteo's free tier will 429 if you push
-    too fast. Debounce the auto-fetch by ~750 ms.
-56. **Tessdata cache is permanent on failure.** `lib/seestar_ocr.js`
-    sets `permanentlyDisabled = true` if init fails once, and
-    never retries even if the env recovers (e.g. CDN comes back up
-    or a sysadmin drops `eng.traineddata` into `vendor/tessdata/`).
-    Reset the flag on SIGHUP, or retry every N minutes.
+55. ✅ **Open-Meteo proxy hammers upstream on every keystroke.** The
+    auto-fetch is now debounced by 750 ms on top of the existing
+    tuple de-dupe.
+56. ✅ **Tessdata cache is permanent on failure.** Init failure now
+    disables OCR for a 10-minute cooldown (`OCR_RETRY_AFTER_MS` to
+    tune) instead of forever, and the bundled-tessdata check runs
+    per-init so dropping `eng.traineddata.gz` into `vendor/tessdata/`
+    is picked up without a restart. `DISABLE_OCR=1` stays permanent.
 
 ### Cosmetic / UX nits
 
-57. **`<tr class="dim">` only dims the text color.** Below-horizon
-    Seestar / planner rows inherit the dim foreground colour, but
-    anchor cells stay the regular accent orange so the visual
-    difference is subtle. Either dim the row background instead
-    or add an `tr.dim a { color: var(--muted); }` override.
-58. **Site-name script flashes the placeholder.** `js/site-name.js`
-    fetches `/api/settings` after the page parses, so the user sees
-    "DeepSkyLog" briefly before the configured name swaps in. Inject
-    the name server-side as a `<meta>` tag, or use a CSS variable
-    set inline in the page head.
-59. **The `_default: 60` in seestar planner response is unused.** Send
-    it or drop it — currently it sits in the JSON for nobody.
-60. **Free-form comet observation has no enforcement of RA/Dec.**
-    Choosing `object_type=COMET` on the upload form makes the comet
-    visible in the gallery, but if the user doesn't also enter
-    RA/Dec the planner can't compute alt-az and the comet vanishes
-    from `/api/planner` and `/api/seestar-planner`. Either flag the
-    missing coords on save, or surface a "won't appear in planners"
-    warning next to the comet option.
+57. ✅ **`<tr class="dim">` only dims the text color.** Added a
+    `tr.dim a { color: var(--fg-dim); }` override so below-horizon
+    rows read as dimmed links too.
+58. ✅ **Site-name script flashes the placeholder.** The configured
+    name is cached in localStorage and applied synchronously on load;
+    the `/api/settings` fetch confirms/corrects it and refreshes the
+    cache, so the flash only happens on the very first visit.
+59. ✅ **The `_default: 60` in seestar planner response is unused.**
+    Kept deliberately: it documents the fallback duration in the API's
+    self-description and the smoke test asserts it. Closing as
+    "decided", not code-changed.
+60. ✅ **Free-form comet observation has no enforcement of RA/Dec.**
+    The upload form now shows a live "won't appear in the planners"
+    warning under the RA/Dec inputs whenever a free-form object type
+    is chosen without coordinates.
 61. **No way to delete a custom list.** The future-ideas backlog
     item #19 (CSV list import) implies users can add lists — once
     that ships, they'll need to be able to remove them too. Add the
     delete path while doing #19.
-62. **`linkish` class still uppercases its label text everywhere it's
-    used.** Fixed for the "Use this device's location" link in PR #57,
-    but the original "browse your files" link on the upload dropzone
-    still uses it. Audit `.linkish` usages and either drop the class
-    entirely or document that it expects short labels.
+62. ✅ **`linkish` class still uppercases its label text everywhere it's
+    used.** Dropped `text-transform: uppercase` / `letter-spacing`
+    from `.linkish`; its one remaining use ("browse your files") now
+    reads as a normal mid-sentence link.
+
+## Fixed in the 2026-07 audit
+
+A full-codebase sweep (server, lib, db, public JS, admin JS). Everything
+below shipped together; listed here so the change log has one home.
+
+- **Dark-moon iCalendar feed was wrong ~93% of the time.** The new-moon
+  search stepped `now + i × synodic`, so every candidate window shared
+  *today's* phase and the ±48 h refine almost never contained a real new
+  moon. Now anchored on the next actual new moon. Also the "closest
+  Saturday" pick always went forward (both branches reduced to `6-day`),
+  putting a Sunday new moon's "dark weekend" six days late — now picks
+  the genuinely nearest Saturday. Covered by a new smoke test.
+- **Catalog progress counts inflated by multi-attempt objects.**
+  `COUNT(lo.id)` after the `LEFT JOIN list_completions` in `/api/lists`
+  and `/api/admin/stats` double-counted objects with >1 completion, so
+  Messier read "N of 111+". Both now `COUNT(DISTINCT lo.id)`; smoke test
+  pins Messier at 110.
+- **FITS `DATE-OBS` parsed as server-local time.** Zone-less FITS dates
+  are UTC by spec; `Date.parse` treated them as local, shifting
+  `observed_at` by the server's UTC offset. Now suffixed with `Z`.
+- **FITS `APERTURE` (objective diameter, mm) rendered as a focal
+  ratio.** A Seestar S50 FITS showed "Aperture f/50.0". `fitsExif` now
+  converts FOCALLEN/APERTURE to a true f-number before storing.
+- **FITS escaped quotes (`''`) truncated string cards** — `OBJECT =
+  'O''Neill Cluster'` parsed as `O`.
+- **Free-form `object_name` was silently discarded.** The upload form
+  and the iOS shortcut both send it, but no column existed — a comet
+  logged as "Comet Lemmon" had no record of the name. New migration 15
+  adds `observations.object_name`; it's inserted, PATCH-editable, and
+  surfaced through every public/admin query via
+  `COALESCE(lo.name, o.object_name)`.
+- **Clearing the default location planted uploads at Null Island.**
+  `/api/settings` coerced the stored `''` with `Number('')` → `0`, so
+  every EXIF-less upload auto-filled (0, 0). Cleared values now come
+  back `null` (smoke-tested).
+- **Upload form wiped NGC-fallback / manually-typed catalog ids at
+  save.** The submit handler re-ran the resolver unconditionally, which
+  clears catalog/number for any non-seeded value — so IC/comet
+  designations saved as NULL and never ticked lists. Resolve now only
+  re-runs when the input matches a seeded row.
+- **Sidecar JSON dropped with an image was discarded** — applied
+  immediately, then wiped seconds later when the stage activated. Now
+  held and applied after the per-image reset.
+- **Telescope selection cleared on every batch-queue advance** despite
+  being documented as shared; manual picks now survive images with no
+  device metadata.
+- **"+ Log another attempt" preselection wiped by the first drop** —
+  the `?object_id=` preselect is now re-applied whenever the staged
+  image carries no target guess of its own.
+- **Edit modal rejected fractional exposures** (`step` mismatch on
+  0.5 s EXIF values) — number fields now use `step="any"`.
+- **★ Feature button 400'd on free-form rows** — hidden where there's
+  no catalog id to feature against.
+- **"Saved observation #N" confirmation erased instantly in batch
+  mode**; the sticky dropzone drag-highlight; the stale sidecar file
+  input; the browse picker refusing `.fits`/`.json` — all fixed.
+- **Observation delete removed image files before the DB transaction**;
+  a failed delete stranded a row with no files. Files now go only after
+  commit. `observed_at` is validated on create (was PATCH-only).
+- **Arrow-key nav on the observation page went the wrong way at either
+  end** (`:first-of-type` matched by element type, not position).
+- **Saved catalog filter silently dropped on planner/tonight/seestar
+  auto-load** — the filter-mounted re-run checked a DOM state that the
+  in-flight load had already cleared. Now tracked with a flag.
+- **Planner "Object" column sorted lexically** (M1, M10, M100, M2…);
+  `0` minutes-above rendered as "—"; `tonight.js` crashed outright on
+  corrupt localStorage; observations at latitude/longitude 0 lost
+  their map; data pages clobbered a configured site name back to
+  "DeepSkyLog" in the tab title.
+- **Atlas "scroll to zoom" was a no-op** (camera distance clamped) —
+  replaced with FOV zoom.
+- **Crossref match radius `0` silently became 6′** (`|| 0.1` on a
+  falsy 0).
+- **GPS hint credited "watermark OCR" for coordinates that came from
+  EXIF GPS** — the stage response now flags the actual source
+  (`coords_from_text`).
+- **OCR hardening:** recognize-timeouts now terminate the stuck shared
+  worker instead of queueing every later upload behind it; the
+  uncaught-exception shim removes only its own listener rather than
+  all of them; astrometry.net responses that are 200-but-HTML surface
+  a readable error instead of a bare SyntaxError.
+
+## Open bugs / hardening (still open after the 2026-07 audit)
+
+63. **"Attempt 1 of 0" on free-form rows with a catalog but no
+    number.** `catalog || catalog_number` is NULL in SQL when either
+    side is NULL, so the sibling query matches nothing while the token
+    is non-empty. Guard the token on *both* parts being present.
+64. **Bulk plate solve accepts an unbounded explicit `ids[]` list.**
+    The no-ids path caps at 50; a crafted payload can queue thousands
+    of sequential Nova uploads. Clamp `ids.length` to the same 50.
+65. **CSV export is vulnerable to spreadsheet formula injection.**
+    A description starting with `=`/`+`/`-`/`@` executes when the CSV
+    is opened in Excel. Prefix such cells with `'` (or a tab) in
+    `/api/observations.csv`.
+66. **`authFailures` / `writeHits` maps grow per-IP without pruning.**
+    Entries for dead IPs are only rewritten when that IP returns.
+    Sweep empty/expired entries on the hourly stage-dir timer.
+67. **Weather/location-stats dedupe keys are global, not per-chip.**
+    Two queued images with identical (date, lat, lon) leave the second
+    chip's weather summary blank because the fetch is deduped away.
+    Reset `lastAutoWeatherKey`/`lastLocationStatsKey` in
+    `resetPerImageFields`.
+68. **Seestar planner: `any` scope never gets Milky Way wide-field
+    targets.** MWWF is gated to `s30pro` scopes only; a single-scope
+    "Any" plan silently excludes them even though "any" may well be an
+    S30 Pro. Consider letting `any` include them with a note.
+69. **Atlas zoom is wheel-only.** The FOV zoom added in the 2026-07
+    audit doesn't handle touch pinch; mobile users still can't zoom.
+    Wire `touchmove` pinch distance to the same FOV clamp.

--- a/db/schema.js
+++ b/db/schema.js
@@ -209,6 +209,17 @@ const MIGRATIONS = [
       DELETE FROM list_objects WHERE catalog = 'MWWF';
     `,
   },
+  {
+    id: 15,
+    name: 'add_observation_object_name',
+    // The upload form and iOS shortcut both send object_name for free-form
+    // targets (comets, anything without a catalog id), but the column never
+    // existed — the name was only used to build the upload path slug and
+    // then discarded. Persist it so the target survives.
+    up: `
+      ALTER TABLE observations ADD COLUMN object_name TEXT;
+    `,
+  },
 ];
 
 module.exports = { MIGRATIONS };

--- a/lib/astrometry.js
+++ b/lib/astrometry.js
@@ -73,7 +73,7 @@ async function postForm(endpoint, fields, fileFieldName, fileBuffer, fileName) {
     await drain(res);
     throw new AstrometryError(`POST ${endpoint} → HTTP ${res.status}`, 'http');
   }
-  return res.json();
+  return parseJsonBody(res, endpoint);
 }
 
 async function getJson(endpoint) {
@@ -84,7 +84,18 @@ async function getJson(endpoint) {
     await drain(res);
     throw new AstrometryError(`GET ${endpoint} → HTTP ${res.status}`, 'http');
   }
-  return res.json();
+  return parseJsonBody(res, endpoint);
+}
+
+// Nova (or a proxy in front of it) occasionally serves HTTP 200 with an
+// HTML maintenance page; surface that as a readable error instead of a
+// bare "Unexpected token '<'" SyntaxError.
+async function parseJsonBody(res, endpoint) {
+  try {
+    return await res.json();
+  } catch {
+    throw new AstrometryError(`${endpoint} returned non-JSON (upstream maintenance?)`, 'badbody');
+  }
 }
 
 async function login() {

--- a/lib/fits.js
+++ b/lib/fits.js
@@ -11,8 +11,10 @@ function parseCard(card) {
   if (card[8] !== '=') return { key, value: null };
   const rest = card.slice(9).trim();
   if (rest.startsWith("'")) {
-    const end = rest.indexOf("'", 1);
-    const str = end > 0 ? rest.slice(1, end) : rest.slice(1);
+    // FITS escapes a literal quote inside a string as '' — match up to the
+    // first *unpaired* closing quote, then unescape. "O''Neill" → "O'Neill".
+    const m = rest.match(/^'((?:[^']|'')*)'/);
+    const str = m ? m[1].replace(/''/g, "'") : rest.slice(1);
     return { key, value: str.replace(/\s+$/, '') };
   }
   const commentIdx = rest.indexOf('/');
@@ -173,7 +175,11 @@ function isFitsPath(p) {
 
 function fitsExif(header) {
   if (!header) return null;
-  const iso = header['DATE-OBS'] ? String(header['DATE-OBS']) : null;
+  // DATE-OBS without a zone suffix is UTC per the FITS standard, but
+  // Date.parse treats zone-less ISO datetimes as server-local time —
+  // append Z so a laptop in any timezone stores the right instant.
+  const raw = header['DATE-OBS'] ? String(header['DATE-OBS']).trim() : null;
+  const iso = raw && !/(?:Z|[+-]\d{2}:?\d{2})$/i.test(raw) ? `${raw}Z` : raw;
   const capturedAt = iso && !Number.isNaN(Date.parse(iso))
     ? new Date(iso).toISOString()
     : null;
@@ -182,6 +188,14 @@ function fitsExif(header) {
     ? header.EXPTIME
     : typeof header.EXPOSURE === 'number' ? header.EXPOSURE : null;
   const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+  // FITS APERTURE is the objective diameter in mm (Seestar S50 writes 50),
+  // but the observations.aperture column holds an EXIF-style focal ratio
+  // (f-number) — convert so the UI's "f/…" rendering stays truthful.
+  const focalLengthMm = num(header.FOCALLEN);
+  const apertureDiameterMm = num(header.APERTURE);
+  const focalRatio = focalLengthMm && apertureDiameterMm
+    ? Math.round((focalLengthMm / apertureDiameterMm) * 10) / 10
+    : null;
   return {
     capturedAt,
     device,
@@ -190,8 +204,8 @@ function fitsExif(header) {
     object: typeof header.OBJECT === 'string' ? header.OBJECT.trim() : null,
     latitude: num(header.SITELAT),
     longitude: num(header.SITELONG),
-    focalLengthMm: num(header.FOCALLEN),
-    aperture: num(header.APERTURE),
+    focalLengthMm,
+    aperture: focalRatio,
   };
 }
 

--- a/lib/seestar_ocr.js
+++ b/lib/seestar_ocr.js
@@ -22,11 +22,32 @@ const OCR_TIMEOUT_MS = Number(process.env.OCR_TIMEOUT_MS) || 20_000;
 // jsdelivr the first time, paying ~10 MB on a cold start.
 const TESSDATA_DIR = path.join(__dirname, '..', 'vendor', 'tessdata');
 const TESSDATA_FILE = path.join(TESSDATA_DIR, 'eng.traineddata.gz');
-const HAS_LOCAL_TESSDATA = fs.existsSync(TESSDATA_FILE)
-  && fs.statSync(TESSDATA_FILE).size > 1_000_000;
+// Checked per-init (not once at module load) so a retry after an admin
+// drops the file into vendor/tessdata/ picks it up without a restart.
+function hasLocalTessdata() {
+  try {
+    return fs.existsSync(TESSDATA_FILE) && fs.statSync(TESSDATA_FILE).size > 1_000_000;
+  } catch {
+    return false;
+  }
+}
 
 let workerPromise = null;
-let permanentlyDisabled = DISABLED;
+
+// A failed init (CDN down, no network) disables OCR for a cooldown rather
+// than forever — the environment can recover (connectivity returns, an
+// admin drops eng.traineddata into vendor/tessdata/). DISABLE_OCR=1 is the
+// only truly permanent switch.
+const RETRY_AFTER_MS = Number(process.env.OCR_RETRY_AFTER_MS) || 10 * 60_000;
+let disabledUntil = DISABLED ? Infinity : 0;
+
+function ocrDisabled() {
+  return Date.now() < disabledUntil;
+}
+
+function disableForCooldown() {
+  if (!DISABLED) disabledUntil = Date.now() + RETRY_AFTER_MS;
+}
 
 // Tesseract.js loads its language data inside a Node Worker thread the first
 // time createWorker resolves. If that load fails (no internet, 403 from the
@@ -49,19 +70,21 @@ function looksLikeTesseractError(err) {
   return false;
 }
 
-process.on('uncaughtException', (err) => {
+function onUncaught(err) {
   if (looksLikeTesseractError(err)) {
     console.warn('Suppressed Tesseract async error:', err?.message || err);
-    permanentlyDisabled = true;
+    disableForCooldown();
     workerPromise = null;
     return;
   }
   // Not ours — defer to Node's default. We can't re-throw out of an
-  // uncaughtException handler usefully, so detach our listener and let the
-  // exception fire again on the next tick where the default handler runs.
-  process.removeAllListeners('uncaughtException');
+  // uncaughtException handler usefully, so detach OUR listener (only ours —
+  // removeAllListeners would strip crash-loggers registered elsewhere) and
+  // let the exception fire again on the next tick.
+  process.removeListener('uncaughtException', onUncaught);
   setImmediate(() => { throw err; });
-});
+}
+process.on('uncaughtException', onUncaught);
 
 function withTimeout(promise, ms, label) {
   return new Promise((resolve, reject) => {
@@ -72,15 +95,16 @@ function withTimeout(promise, ms, label) {
 }
 
 async function getWorker() {
-  if (permanentlyDisabled) return null;
+  if (ocrDisabled()) return null;
   if (workerPromise) {
     try { return await workerPromise; } catch { return null; }
   }
   workerPromise = (async () => {
     try {
       const { createWorker } = require('tesseract.js');
-      const opts = HAS_LOCAL_TESSDATA ? { langPath: TESSDATA_DIR } : {};
-      if (HAS_LOCAL_TESSDATA) {
+      const local = hasLocalTessdata();
+      const opts = local ? { langPath: TESSDATA_DIR } : {};
+      if (local) {
         console.log(`OCR: using bundled traineddata at ${TESSDATA_DIR}`);
       } else {
         console.log('OCR: bundled traineddata missing, will fetch from CDN');
@@ -88,9 +112,12 @@ async function getWorker() {
       const w = await withTimeout(createWorker('eng', 1, opts), INIT_TIMEOUT_MS, 'OCR init');
       return w;
     } catch (err) {
-      permanentlyDisabled = true;
+      disableForCooldown();
       workerPromise = null;
-      console.warn('Tesseract initialisation failed, disabling OCR:', err.message);
+      console.warn(
+        `Tesseract initialisation failed, disabling OCR for ${Math.round(RETRY_AFTER_MS / 60_000)} min:`,
+        err.message,
+      );
       throw err;
     }
   })();
@@ -115,7 +142,7 @@ async function cropBanner(imagePath) {
 }
 
 async function ocrBanner(imagePath) {
-  if (permanentlyDisabled) return null;
+  if (ocrDisabled()) return null;
   let buffer;
   try { buffer = await cropBanner(imagePath); } catch { return null; }
   if (!buffer) return null;
@@ -128,6 +155,13 @@ async function ocrBanner(imagePath) {
     return (result?.data?.text || '').trim() || null;
   } catch (err) {
     console.warn('OCR failed:', err.message);
+    if (/timed out/.test(String(err.message))) {
+      // The abandoned job is still running inside the shared worker; reusing
+      // it would make every subsequent upload queue behind the stuck one.
+      // Kill it and let the next call spin up a fresh worker.
+      workerPromise = null;
+      worker.terminate().catch(() => {});
+    }
     return null;
   }
 }

--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -116,13 +116,23 @@ const controls = new OrbitControls(camera, renderer.domElement);
 // from the origin.
 controls.target.set(0, 0, 1);
 controls.enablePan = false;
-controls.enableZoom = true;
-controls.zoomSpeed = 0.8;
+// OrbitControls "zoom" dollies the camera along the view axis, but the
+// camera is pinned at the origin (min/maxDistance below), so wheel/pinch
+// was a silent no-op. Zoom by narrowing the camera FOV instead — the
+// natural mechanic for a viewer standing inside a celestial sphere.
+controls.enableZoom = false;
 controls.rotateSpeed = -0.35; // negative so drag-right looks right
 controls.minDistance = 0.1;
 controls.maxDistance = 0.1;  // forces camera to stay near origin
 controls.minPolarAngle = 0;
 controls.maxPolarAngle = Math.PI;
+
+const FOV_MIN = 15, FOV_MAX = 95;
+renderer.domElement.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  camera.fov = Math.min(FOV_MAX, Math.max(FOV_MIN, camera.fov + e.deltaY * 0.05));
+  camera.updateProjectionMatrix();
+}, { passive: false });
 
 // Soft inner background sphere so we can see "behind" missing tiles.
 const bg = new THREE.Mesh(

--- a/public/js/list.js
+++ b/public/js/list.js
@@ -13,7 +13,9 @@ async function load() {
   try {
     const data = await fetchJson(`/api/lists/${encodeURIComponent(slug)}`);
     state.objects = data.objects;
-    document.title = `DeepSkyLog — ${data.name}`;
+    // Keep whatever brand prefix site-name.js resolved instead of
+    // hardcoding "DeepSkyLog" back over a configured site name.
+    document.title = `${document.title.split(' — ')[0]} — ${data.name}`;
     document.getElementById('list-name').textContent = data.name;
     document.getElementById('list-description').textContent = data.description || '';
 

--- a/public/js/object.js
+++ b/public/js/object.js
@@ -41,7 +41,9 @@ async function render() {
     root.innerHTML = '<p class="muted">Object not found.</p>';
     return;
   }
-  document.title = `DeepSkyLog — ${data.catalog}${data.catalog_number}`;
+  // Keep whatever brand prefix site-name.js resolved instead of
+  // hardcoding "DeepSkyLog" back over a configured site name.
+  document.title = `${document.title.split(' — ')[0]} — ${data.catalog}${data.catalog_number}`;
 
   root.innerHTML = '';
   root.appendChild(el('p', { class: 'dim' },

--- a/public/js/observation.js
+++ b/public/js/observation.js
@@ -77,7 +77,7 @@ function moonSvg(phase) {
 
 function locationCard(o) {
   const wrap = el('div', { class: 'meta-list', style: 'margin-top:0.5rem;' });
-  if (!o.latitude || !o.longitude) {
+  if (o.latitude == null || o.longitude == null) {
     wrap.appendChild(el('p', { class: 'dim', text: o.location || 'No GPS recorded.' }));
     return wrap;
   }
@@ -137,7 +137,9 @@ async function render() {
   }
   const o = data.observation;
   const targetLabel = (o.catalog && o.catalog_number) ? `${o.catalog}${o.catalog_number}` : (o.title || `#${o.id}`);
-  document.title = `DeepSkyLog — ${targetLabel}`;
+  // Preserve whatever brand prefix site-name.js resolved — hardcoding
+  // "DeepSkyLog" here would clobber a configured site name.
+  document.title = `${document.title.split(' — ')[0]} — ${targetLabel}`;
 
   root.innerHTML = '';
 
@@ -161,10 +163,10 @@ async function render() {
   // Prev/next nav
   const navRow = el('div', { class: 'obs-nav' });
   const prev = data.prev_id
-    ? el('a', { class: 'button-link ghost-link', href: `/observation.html?id=${data.prev_id}`, text: '← Previous' })
+    ? el('a', { class: 'button-link ghost-link nav-prev', href: `/observation.html?id=${data.prev_id}`, text: '← Previous' })
     : el('span', { class: 'button-link ghost-link', style: 'opacity:0.5; pointer-events:none;', text: '← Previous' });
   const next = data.next_id
-    ? el('a', { class: 'button-link ghost-link', href: `/observation.html?id=${data.next_id}`, text: 'Next →' })
+    ? el('a', { class: 'button-link ghost-link nav-next', href: `/observation.html?id=${data.next_id}`, text: 'Next →' })
     : el('span', { class: 'button-link ghost-link', style: 'opacity:0.5; pointer-events:none;', text: 'Next →' });
   navRow.appendChild(prev);
   navRow.appendChild(el('span', { class: 'pos dim',
@@ -248,9 +250,10 @@ async function render() {
 document.addEventListener('keydown', (e) => {
   if (e.target && /^(input|textarea|select)$/i.test(e.target.tagName)) return;
   if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
-  const link = document.querySelector(
-    e.key === 'ArrowLeft' ? '.obs-nav a[href*="/observation.html"]:first-of-type' : '.obs-nav a[href*="/observation.html"]:last-of-type',
-  );
+  // Explicit classes: :first-of-type / :last-of-type match by *element
+  // type*, so when the Previous slot is a disabled <span> the Next anchor
+  // was both first and last <a>, and ArrowLeft navigated forward.
+  const link = document.querySelector(e.key === 'ArrowLeft' ? '.obs-nav a.nav-prev' : '.obs-nav a.nav-next');
   if (link) link.click();
 });
 

--- a/public/js/planner.js
+++ b/public/js/planner.js
@@ -1,19 +1,21 @@
-import { fetchJson, el, typeLabel, highlightNav } from './common.js';
+import { fetchJson, el, typeLabel, highlightNav, catalogSortKey } from './common.js';
 import { mountCatalogFilter, selectionToParam } from './catalog-filter.js';
 import { mountTypeFilter, typesToParam } from './type-filter.js';
 
 highlightNav('planner');
 
 let getCatalogSelection = () => [];
+let loadRan = false; // a load was kicked off before the filter mounted
 mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   // Re-plan automatically when the catalog set changes — the user
   // would otherwise have to tap Plan again.
   load();
 }).then((fn) => {
   getCatalogSelection = fn;
-  // If the page auto-ran load() before the filter was ready, re-run
-  // now that we know which catalogs the user wants.
-  if (rows.children.length) load();
+  // If the page auto-ran load() before the filter was ready, re-run now
+  // that we know which catalogs the user wants. (Checking the DOM here
+  // raced: load() clears the tbody before its fetch resolves.)
+  if (loadRan) load();
 });
 const getTypeSelection = mountTypeFilter(document.getElementById('type-filter'), () => load());
 
@@ -55,7 +57,7 @@ function fmtTime(iso) {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 function fmtMinutes(m) {
-  if (!m) return '—';
+  if (m == null) return '—';
   if (m < 60) return `${m}m`;
   const h = Math.floor(m / 60);
   const mm = m % 60;
@@ -65,7 +67,7 @@ function fmtMinutes(m) {
 // Per-column extractors. Strings sort case-insensitively; nullish values
 // always sink to the bottom regardless of direction.
 const COLUMN_GETTERS = {
-  object:        (t) => `${t.catalog || ''}${t.catalog_number || ''}`.toLowerCase(),
+  object:        (t) => catalogSortKey(t.catalog, t.catalog_number).toLowerCase(),
   name:          (t) => (t.name || '').toLowerCase(),
   type:          (t) => (t.object_type || '').toLowerCase(),
   constellation: (t) => (t.constellation || '').toLowerCase(),
@@ -117,6 +119,7 @@ async function load() {
     return;
   }
   localStorage.setItem(STORE_KEY, JSON.stringify({ lat, lon }));
+  loadRan = true;
 
   status.textContent = 'Computing…';
   rows.innerHTML = '';

--- a/public/js/seestar-plan.js
+++ b/public/js/seestar-plan.js
@@ -6,11 +6,15 @@ import { mountDurationPicker } from './seestar-durations.js';
 highlightNav('seestar');
 
 let getCatalogSelection = () => [];
+let loadRan = false; // a load was kicked off before the filters mounted
 mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   load();
 }).then((fn) => {
   getCatalogSelection = fn;
-  if (schedules.children.length) load();
+  // Re-run any auto-load that went out without the saved filter. Checking
+  // the DOM here raced: load() clears the container before its fetch
+  // resolves, so this then() usually saw it empty and skipped the re-run.
+  if (loadRan) load();
 });
 const getTypeSelection = mountTypeFilter(document.getElementById('type-filter'), () => load());
 
@@ -19,7 +23,7 @@ mountDurationPicker(document.getElementById('duration-filter'), () => {
   load();
 }).then((fn) => {
   getDurationParam = fn;
-  if (schedules.children.length) load();
+  if (loadRan) load();
 });
 
 const dateInput = document.getElementById('date-input');
@@ -127,6 +131,7 @@ async function load() {
     return;
   }
   localStorage.setItem(STORE_KEY, JSON.stringify({ lat, lon }));
+  loadRan = true;
 
   status.textContent = 'Planning…';
   schedules.innerHTML = '';

--- a/public/js/site-name.js
+++ b/public/js/site-name.js
@@ -1,7 +1,32 @@
 // Fetches the configured site name and patches the brand label + document
 // title on every page. Loaded as a side-effect from each HTML file.
+//
+// The API round-trip means the default "DeepSkyLog" is briefly visible on a
+// cold load. To avoid that flash on every subsequent visit we cache the
+// configured name in localStorage and apply it synchronously before the
+// fetch; the fetch then confirms (or corrects) it and refreshes the cache.
+//
+// applyName transforms whatever is currently rendered (replacing the last
+// applied name) rather than restoring a snapshot, so it composes with page
+// modules that set their own "<brand> — <thing>" titles at any time.
+
+const CACHE_KEY = 'dsl_site_name';
+let lastApplied = 'DeepSkyLog';
+
+function applyName(name) {
+  if (!name || name === lastApplied) return;
+  for (const node of document.querySelectorAll('.brand-name')) {
+    node.textContent = node.textContent.split(lastApplied).join(name);
+  }
+  if (document.title) document.title = document.title.split(lastApplied).join(name);
+  lastApplied = name;
+}
 
 (async () => {
+  let cached = null;
+  try { cached = localStorage.getItem(CACHE_KEY); } catch {}
+  if (cached) applyName(cached);
+
   let name;
   try {
     const res = await fetch('/api/settings');
@@ -9,9 +34,7 @@
     const data = await res.json();
     name = data?.site_name;
   } catch { return; }
-  if (!name || name === 'DeepSkyLog') return;
-  for (const node of document.querySelectorAll('.brand-name')) {
-    node.textContent = node.textContent.replace(/DeepSkyLog/g, name);
-  }
-  if (document.title) document.title = document.title.replace(/DeepSkyLog/g, name);
+  if (!name) return;
+  try { localStorage.setItem(CACHE_KEY, name); } catch {}
+  applyName(name); // no-op when the cache was already right
 })();

--- a/public/js/tonight.js
+++ b/public/js/tonight.js
@@ -5,11 +5,16 @@ import { mountTypeFilter, typesToParam } from './type-filter.js';
 highlightNav('tonight');
 
 let getCatalogSelection = () => [];
+let loadRan = false; // a load was kicked off before the filter mounted
 mountCatalogFilter(document.getElementById('catalog-filter'), () => {
   load();
 }).then((fn) => {
   getCatalogSelection = fn;
-  if (rows.children.length) load();
+  // Re-run any auto-load that went out without the saved filter. Checking
+  // the DOM (rows.children.length) raced: load() clears the tbody before
+  // its fetch resolves, so this then() usually saw an empty table and the
+  // unfiltered result silently won.
+  if (loadRan) load();
 });
 const getTypeSelection = mountTypeFilter(document.getElementById('type-filter'), () => load());
 
@@ -24,8 +29,10 @@ const moonLine = document.getElementById('moon-line');
 const rows = document.getElementById('rows');
 
 const STORE_KEY = 'deepskylog.location';
-const stored = JSON.parse(localStorage.getItem(STORE_KEY) || 'null');
-if (stored) {
+let stored = null;
+try { stored = JSON.parse(localStorage.getItem(STORE_KEY) || 'null'); }
+catch { /* corrupt — ignore */ }
+if (stored && Number.isFinite(Number(stored.lat)) && Number.isFinite(Number(stored.lon))) {
   latInput.value = stored.lat;
   lonInput.value = stored.lon;
 }
@@ -50,6 +57,7 @@ async function load() {
     return;
   }
   localStorage.setItem(STORE_KEY, JSON.stringify({ lat, lon }));
+  loadRan = true;
 
   status.textContent = 'Computing…';
   rows.innerHTML = '';

--- a/public/styles.css
+++ b/public/styles.css
@@ -149,6 +149,9 @@ h4 { font-size: 0.95rem; color: var(--peach); margin: 0; }
 
 .muted { color: var(--muted); }
 .dim { color: var(--fg-dim); }
+/* Below-horizon planner rows: dim the links too, or the accent-coloured
+   anchors make the row look no different from an active one. */
+tr.dim a { color: var(--fg-dim); }
 
 /* ---------- Cards (catalog tiles) ---------- */
 

--- a/server.js
+++ b/server.js
@@ -210,9 +210,30 @@ function timingSafeCompare(a, b) {
   return crypto.timingSafeEqual(ab, bb);
 }
 
+// Cross-origin write protection. Browsers attach cached Basic-Auth
+// credentials to cross-site requests, so a hostile page could POST a
+// delete on the admin's behalf. Browsers always send an Origin header on
+// cross-origin fetch/XHR/form POSTs; when it's present and its host
+// doesn't match the Host the request arrived on, reject. Requests with no
+// Origin header (curl, same-origin GET navigations, old clients) pass —
+// this only needs to stop credentialed cross-site browser writes.
+function sameOriginWrite(req) {
+  if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') return true;
+  const origin = req.headers.origin;
+  if (!origin) return true;               // curl / non-browser clients
+  if (origin === 'null') return false;    // sandboxed iframe / file://
+  let originHost;
+  try { originHost = new URL(origin).host; } catch { return false; }
+  return originHost === req.headers.host;
+}
+
 function basicAuth(req, res, next) {
   if (!ADMIN_PASSWORD) {
     return res.status(503).json({ error: 'ADMIN_PASSWORD not configured on server' });
+  }
+
+  if (!sameOriginWrite(req)) {
+    return res.status(403).json({ error: 'Cross-origin write rejected' });
   }
 
   const ip = clientIp(req);
@@ -347,7 +368,7 @@ app.get('/api/lists', (_req, res) => {
   const lists = db
     .prepare(
       `SELECT l.id, l.slug, l.name, l.description, l.builtin,
-              COUNT(lo.id) AS object_count,
+              COUNT(DISTINCT lo.id) AS object_count,
               COUNT(DISTINCT lc.list_object_id) AS completed_count
          FROM lists l
          LEFT JOIN list_objects lo ON lo.list_id = l.id
@@ -414,7 +435,7 @@ app.get('/api/observations', (req, res) => {
   const rows = db
     .prepare(
       `SELECT o.*, lo.catalog AS object_catalog, lo.catalog_number AS object_catalog_number,
-              lo.name AS object_name,
+              COALESCE(lo.name, o.object_name) AS object_name,
               COALESCE(lo.object_type, o.object_type) AS object_type,
               lo.constellation AS constellation
          FROM observations o
@@ -865,7 +886,6 @@ app.get('/api/seestar-planner', (req, res) => {
     const wideFieldOK = scopeDef === SEESTAR_SCOPES.s30pro;
     const plan = [];
     let cursor = sessionStart.getTime();
-    let stalled = 0;
     while (cursor < sessionEnd.getTime()) {
       const slotStart = new Date(cursor);
       let best = null;
@@ -897,13 +917,13 @@ app.get('/api/seestar-planner', (req, res) => {
         }
       }
       if (!best) {
-        stalled += 1;
-        // Bail after an hour of stalled retries — no point looping forever.
-        if (stalled > 4) break;
+        // Nothing fits right now — step forward and retry. A dry spell can
+        // last hours on a narrow types= filter (everything set, next batch
+        // not yet risen); the loop is bounded by sessionEnd, so keep walking
+        // instead of giving up on the rest of the night.
         cursor += 15 * 60_000;
         continue;
       }
-      stalled = 0;
       assignedIds.add(best.row.id);
       plan.push({
         slot_start: slotStart.toISOString(),
@@ -1080,7 +1100,7 @@ app.get('/api/observations/map', (_req, res) => {
       `SELECT o.id, o.title, o.observed_at, o.latitude, o.longitude, o.location,
               o.telescope, o.thumbnail_path, o.object_id,
               lo.catalog AS object_catalog, lo.catalog_number AS object_catalog_number,
-              lo.name AS object_name
+              COALESCE(lo.name, o.object_name) AS object_name
          FROM observations o
          LEFT JOIN list_objects lo ON lo.id = o.object_id
          WHERE o.latitude IS NOT NULL AND o.longitude IS NOT NULL`,
@@ -1101,7 +1121,7 @@ app.get('/api/observations/atlas', (_req, res) => {
               o.solved_radius_deg, o.solved_orientation_deg, o.solved_pixscale,
               o.telescope, o.object_id,
               lo.catalog AS object_catalog, lo.catalog_number AS object_catalog_number,
-              lo.name AS object_name, lo.object_type
+              COALESCE(lo.name, o.object_name) AS object_name, lo.object_type
          FROM observations o
          LEFT JOIN list_objects lo ON lo.id = o.object_id
          WHERE o.solved_ra_hours IS NOT NULL
@@ -1138,7 +1158,8 @@ app.get('/api/observations.csv', (_req, res) => {
   const rows = db
     .prepare(
       `SELECT o.id, o.observed_at, o.created_at, o.title, o.catalog, o.catalog_number,
-              lo.name AS object_name, lo.object_type, lo.constellation,
+              COALESCE(lo.name, o.object_name) AS object_name,
+              COALESCE(lo.object_type, o.object_type) AS object_type, lo.constellation,
               o.telescope, o.camera, o.location, o.latitude, o.longitude,
               o.exposure_seconds, o.iso, o.gain, o.stack_count, o.filter_name,
               o.focal_length_mm, o.aperture,
@@ -1244,9 +1265,17 @@ app.get('/api/calendar/dark-moon.ics', (_req, res) => {
   // Find each new moon in the next year by stepping ~one synodic month and
   // refining via local search. moonPhase().phase is 0 at new moon, so we
   // minimise that against zero, accounting for the 0/1 wraparound.
+  //
+  // The stepping must start from the NEXT NEW MOON, not from `now` — centres
+  // spaced i×synodic from `now` all share now's phase, and the ±48 h refine
+  // window only contains a real new moon when `now` happens to be near one.
+  const phaseNow = moonPhase(now).phase;
+  const msToNewMoon = ((1 - phaseNow) % 1) * SYNODIC_MS;
+  const firstNewMoon = now.getTime() + msToNewMoon;
+
   const events = [];
   for (let i = 0; i < 13; i++) {
-    let centre = new Date(now.getTime() + i * SYNODIC_MS);
+    let centre = new Date(firstNewMoon + i * SYNODIC_MS);
     // Refine ±2 days at hour granularity.
     let best = centre;
     let bestPhase = 1;
@@ -1259,8 +1288,10 @@ app.get('/api/calendar/dark-moon.ics', (_req, res) => {
     if (best.getTime() < now.getTime() - 86_400_000) continue;
 
     // Pick the Saturday closest to the new moon as the centre of the weekend.
+    // Sun/Mon/Tue are nearer the previous Saturday (1–3 days back); Wed–Fri
+    // are nearer the next one (1–3 days forward); Saturday stays put.
     const day = best.getUTCDay();           // 0=Sun..6=Sat
-    const offsetToSat = day <= 3 ? (6 - day) : -(day - 6);
+    const offsetToSat = day <= 2 ? -(day + 1) : 6 - day;
     const sat = new Date(Date.UTC(best.getUTCFullYear(), best.getUTCMonth(), best.getUTCDate() + offsetToSat));
     const fri = new Date(sat.getTime() - 86_400_000);
     const monAfter = new Date(sat.getTime() + 2 * 86_400_000);   // exclusive end
@@ -1554,9 +1585,13 @@ app.get('/api/settings', (_req, res) => {
   const rows = db.prepare(`SELECT key, value FROM site_settings`).all();
   const out = { site_name: 'DeepSkyLog' };
   for (const r of rows) out[r.key] = r.value;
-  // Coerce known numeric keys for the client's convenience.
-  if (out.default_latitude != null) out.default_latitude = Number(out.default_latitude);
-  if (out.default_longitude != null) out.default_longitude = Number(out.default_longitude);
+  // Coerce known numeric keys for the client's convenience. A cleared value
+  // is stored as '' — that must come back as null, not Number('') === 0,
+  // or clearing the default location plants every upload at Null Island.
+  for (const key of ['default_latitude', 'default_longitude']) {
+    if (out[key] == null || out[key] === '') out[key] = null;
+    else out[key] = Number(out[key]);
+  }
   res.json(out);
 });
 
@@ -2015,7 +2050,7 @@ app.get('/api/admin/stats', basicAuth, (_req, res) => {
   const lists = db
     .prepare(
       `SELECT l.slug, l.name,
-              COUNT(lo.id) AS object_count,
+              COUNT(DISTINCT lo.id) AS object_count,
               COUNT(DISTINCT lc.list_object_id) AS completed_count
          FROM lists l
          LEFT JOIN list_objects lo ON lo.list_id = l.id
@@ -2030,7 +2065,7 @@ app.get('/api/admin/stats', basicAuth, (_req, res) => {
       `SELECT o.id AS observation_id, o.object_id AS object_list_id,
               o.title, o.observed_at, o.created_at, o.telescope,
               o.rating, o.thumbnail_path, o.image_path, o.catalog, o.catalog_number,
-              lo.name AS object_name
+              COALESCE(lo.name, o.object_name) AS object_name
          FROM observations o
          LEFT JOIN list_objects lo ON lo.id = o.object_id
          ORDER BY o.created_at DESC
@@ -2219,7 +2254,10 @@ function angularSepDeg(ra1h, dec1, ra2h, dec2) {
 // each other, so the admin can review and link likely-same targets that the
 // seed aliases missed.
 app.get('/api/admin/crossref', basicAuth, (req, res) => {
-  const tol = Math.min(Math.max(Number(req.query.tol) || 0.1, 0), 2); // degrees
+  // 0 is a legitimate value ("no proximity suggestions") — only fall back
+  // to the 0.1° default when the param is missing/unparseable.
+  const tolRaw = Number(req.query.tol);
+  const tol = Math.min(Math.max(Number.isFinite(tolRaw) ? tolRaw : 0.1, 0), 2); // degrees
   const rows = db
     .prepare(
       `SELECT lo.id, lo.catalog, lo.catalog_number, lo.name, lo.object_type,
@@ -2468,7 +2506,11 @@ app.post('/api/admin/stage', basicAuth, stageUpload.single('image'), async (req,
   // currently has nothing (sub-second EXIF exposure shouldn't be clobbered
   // by a watermark "52min", which is total integration; we put that in a
   // separate field for the UI to interpret).
-  if (latitude == null && guesses.coords?.latitude != null) latitude = guesses.coords.latitude;
+  let coordsFromText = false;   // true when lat/lon came from OCR/EXIF text mining, not GPS tags
+  if (latitude == null && guesses.coords?.latitude != null) {
+    latitude = guesses.coords.latitude;
+    coordsFromText = true;
+  }
   if (longitude == null && guesses.coords?.longitude != null) longitude = guesses.coords.longitude;
   if (!capturedIso && guesses.captured_at) capturedIso = guesses.captured_at;
   if (!objectName && guesses.target?.raw) objectName = guesses.target.raw;
@@ -2498,6 +2540,7 @@ app.post('/api/admin/stage', basicAuth, stageUpload.single('image'), async (req,
       total_exposure_seconds: guesses.exposure_seconds_total,
       photographer: guesses.photographer,
       from_ocr: !!ocrText,
+      coords_from_text: coordsFromText,
       from_filename: !!fileGuess,
       ocr_error: ocrError,
     },
@@ -2541,6 +2584,11 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
   const location = body.location ? String(body.location).trim() : null;
   const notes = body.notes ? String(body.notes).trim() : null;
   const observedAt = body.observed_at ? String(body.observed_at).trim() : null;
+  // Same guard as the PATCH endpoint: a garbage date would silently break
+  // COALESCE(observed_at, …) ordering everywhere.
+  if (observedAt && Number.isNaN(Date.parse(observedAt))) {
+    return res.status(400).json({ error: 'observed_at is not a parseable date' });
+  }
   const title = body.title ? String(body.title).trim() : null;
   const clamp = (v, lo, hi) => {
     if (v == null || v === '') return null;
@@ -2700,13 +2748,13 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
         aperture, image_path, thumbnail_path, exif_json, rating,
         latitude, longitude, seeing, transparency, moon_phase,
         moon_phase_name, bortle, stack_count, gain, filter_name, device_json,
-        object_type, ra_hours, dec_degrees, sqm)
+        object_type, ra_hours, dec_degrees, sqm, object_name)
      VALUES (@object_id, @catalog, @catalog_number, @title, @description, @observed_at,
              @location, @telescope, @camera, @exposure_seconds, @iso, @focal_length_mm,
              @aperture, @image_path, @thumbnail_path, @exif_json, @rating,
              @latitude, @longitude, @seeing, @transparency, @moon_phase,
              @moon_phase_name, @bortle, @stack_count, @gain, @filter_name, @device_json,
-             @object_type, @ra_hours, @dec_degrees, @sqm)`,
+             @object_type, @ra_hours, @dec_degrees, @sqm, @object_name)`,
   );
 
   const completeList = db.prepare(
@@ -2749,6 +2797,9 @@ app.post('/api/admin/observations', basicAuth, async (req, res) => {
       ra_hours: observationRaHours,
       dec_degrees: observationDecDegrees,
       sqm,
+      // Free-form target name (comets, anything without a catalog id) —
+      // persisted so the target isn't lost when there's no list row.
+      object_name: matchedObject ? null : objectName,
     });
 
     const observationId = Number(result.lastInsertRowid);
@@ -2829,6 +2880,7 @@ app.patch('/api/admin/observations/:id', basicAuth, (req, res) => {
 
   const updates = {};
   if ('title' in body)            updates.title = str(body.title, 200);
+  if ('object_name' in body)      updates.object_name = str(body.object_name, 200);
   if ('description' in body)      updates.description = body.description == null ? null : String(body.description);
   if ('observed_at' in body)      updates.observed_at = str(body.observed_at, 40);
   if ('location' in body)         updates.location = str(body.location, 200);
@@ -2905,7 +2957,31 @@ app.delete('/api/admin/observations/:id', basicAuth, (req, res) => {
   const row = db.prepare('SELECT * FROM observations WHERE id = ?').get(id);
   if (!row) return res.status(404).json({ error: 'Observation not found' });
 
-  // Best-effort file cleanup, scoped to UPLOAD_DIR.
+  const tx = db.transaction(() => {
+    db.prepare('DELETE FROM list_completions WHERE observation_id = ?').run(id);
+    db.prepare('DELETE FROM observations WHERE id = ?').run(id);
+
+    // If the deleted row was featured, promote the most recent remaining
+    // attempt with an image so the object still has a cover.
+    if (row.featured && row.catalog && row.catalog_number) {
+      const next = db
+        .prepare(
+          `SELECT id FROM observations
+             WHERE catalog = ? AND catalog_number = ? AND image_path IS NOT NULL
+             ORDER BY COALESCE(observed_at, created_at) DESC
+             LIMIT 1`,
+        )
+        .get(row.catalog, row.catalog_number);
+      if (next) {
+        db.prepare('UPDATE observations SET featured = 1 WHERE id = ?').run(next.id);
+      }
+    }
+  });
+  tx();
+
+  // Best-effort file cleanup, scoped to UPLOAD_DIR — only after the DB
+  // delete committed, so a failed transaction never strands a row whose
+  // image files are already gone.
   const tryUnlink = (rel) => {
     if (!rel) return;
     const full = path.resolve(UPLOAD_DIR, rel);
@@ -2931,28 +3007,6 @@ app.delete('/api/admin/observations/:id', basicAuth, (req, res) => {
       dir = path.dirname(dir);
     }
   }
-
-  const tx = db.transaction(() => {
-    db.prepare('DELETE FROM list_completions WHERE observation_id = ?').run(id);
-    db.prepare('DELETE FROM observations WHERE id = ?').run(id);
-
-    // If the deleted row was featured, promote the most recent remaining
-    // attempt with an image so the object still has a cover.
-    if (row.featured && row.catalog && row.catalog_number) {
-      const next = db
-        .prepare(
-          `SELECT id FROM observations
-             WHERE catalog = ? AND catalog_number = ? AND image_path IS NOT NULL
-             ORDER BY COALESCE(observed_at, created_at) DESC
-             LIMIT 1`,
-        )
-        .get(row.catalog, row.catalog_number);
-      if (next) {
-        db.prepare('UPDATE observations SET featured = 1 WHERE id = ?').run(next.id);
-      }
-    }
-  });
-  tx();
 
   res.status(204).end();
 });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1100,6 +1100,87 @@ test('smoke', async (t) => {
 
   // Run last — consumes the per-IP failure budget, so any admin call after
   // this one gets a 429 until the 15-minute window rolls over.
+  await t.test('cross-origin admin writes are rejected, same-origin pass', async () => {
+    const cross = await doFetch('/api/admin/settings', {
+      method: 'PUT', auth: true,
+      headers: { Origin: 'https://evil.example' },
+      body: { site_name: 'Hacked' },
+    });
+    assert.equal(cross.status, 403, 'cross-origin PUT rejected');
+    const host = new URL(baseUrl).host;
+    const same = await doFetch('/api/admin/settings', {
+      method: 'PUT', auth: true,
+      headers: { Origin: `http://${host}` },
+      body: { site_name: 'DeepSkyLog' },
+    });
+    assert.equal(same.status, 200, 'same-origin PUT accepted');
+    // No Origin header (curl, scripts) — allowed.
+    const bare = await doFetch('/api/admin/settings', {
+      method: 'PUT', auth: true, body: { site_name: 'DeepSkyLog' },
+    });
+    assert.equal(bare.status, 200, 'origin-less PUT accepted');
+  });
+
+  await t.test('cleared default location comes back null, not 0', async () => {
+    await fetchJsonAuthed('/api/admin/settings', {
+      method: 'PUT', body: { default_latitude: 51.5, default_longitude: -0.1 },
+    });
+    await fetchJsonAuthed('/api/admin/settings', {
+      method: 'PUT', body: { default_latitude: '', default_longitude: '' },
+    });
+    const settings = await doFetch('/api/settings', { parse: 'json' });
+    assert.equal(settings.default_latitude, null, 'cleared latitude is null');
+    assert.equal(settings.default_longitude, null, 'cleared longitude is null');
+  });
+
+  await t.test('list object_count is not inflated by multiple completions', async () => {
+    // The upload tests above logged more than one observation against the
+    // same targets; COUNT without DISTINCT double-counted list_objects rows.
+    const lists = await fetchJsonAuthed('/api/lists');
+    const messier = lists.find((l) => l.slug === 'messier');
+    assert.equal(messier.object_count, 110, `Messier must stay 110, got ${messier.object_count}`);
+  });
+
+  await t.test('free-form object_name is persisted and surfaced', async () => {
+    const jpeg = await buildSyntheticJpeg();
+    const fd = new FormData();
+    fd.append('image', new Blob([jpeg], { type: 'image/jpeg' }), 'comet.jpg');
+    const staged = await fetchJsonAuthed('/api/admin/stage', { method: 'POST', body: fd });
+    const saved = await fetchJsonAuthed('/api/admin/observations', {
+      method: 'POST',
+      body: {
+        stage_id: staged.stage_id,
+        telescope: 'Seestar S50',
+        object_name: 'Comet Lemmon',
+        object_type: 'COMET',
+      },
+    });
+    const rows = await doFetch('/api/observations', { parse: 'json' });
+    const row = rows.find((r) => r.id === saved.id);
+    assert.equal(row.object_name, 'Comet Lemmon', 'free-form target name survives');
+    await fetchAuthed(`/api/admin/observations/${saved.id}`, { method: 'DELETE' });
+  });
+
+  await t.test('dark-moon events land on actual new moons', async () => {
+    const res = await fetch(`${baseUrl}/api/calendar/dark-moon.ics`);
+    const ics = await res.text();
+    const { moonPhase } = require(path.join(ROOT, 'lib', 'astro'));
+    const starts = [...ics.matchAll(/DTSTART;VALUE=DATE:(\d{8})/g)].map((m) => m[1]);
+    assert.ok(starts.length >= 10, 'a year of events');
+    for (const s of starts.slice(0, 3)) {
+      // Friday start + 1 day = the Saturday nearest the new moon; the new
+      // moon itself is within ±3 days of that Saturday, so illumination
+      // anywhere in the window must be low.
+      const sat = new Date(Date.UTC(+s.slice(0, 4), +s.slice(4, 6) - 1, +s.slice(6, 8) + 1));
+      let minIllum = 1;
+      for (let d = -3; d <= 3; d++) {
+        const p = moonPhase(new Date(sat.getTime() + d * 86_400_000));
+        minIllum = Math.min(minIllum, p.illumination);
+      }
+      assert.ok(minIllum < 0.05, `weekend near ${s} should bracket a new moon (min illum ${minIllum.toFixed(2)})`);
+    }
+  });
+
   await t.test('rate limit triggers 429 after 20 failures', async () => {
     let saw429 = false;
     for (let i = 0; i < 25; i++) {


### PR DESCRIPTION
## Summary

A full sweep of the codebase (server, `lib/`, `db/`, public JS, admin JS) fixing every verified bug found, closing 8 open backlog items, and hardening a few security-adjacent paths. `backlog.md` gains a "Fixed in the 2026-07 audit" changelog section and 7 newly-found open items (#63–69).

## Highest-impact fixes

- **Dark-moon iCalendar feed was wrong ~93% of the time.** Event centres stepped `now + i × synodic`, so every candidate window shared the *request date's* lunar phase — a real new moon only fell inside the ±48 h refine window when you happened to request the feed near one. Events are now anchored on the next actual new moon, and the "closest Saturday" pick no longer always goes forward (both branches of the old ternary were identical), which had put Sunday-new-moon "dark weekends" six days late at a ~30%-lit moon.
- **Catalog progress denominators were inflated** once any object had multiple attempts — `COUNT(lo.id)` after the `LEFT JOIN list_completions` double-counts. Messier read "N of 111+". Now `COUNT(DISTINCT lo.id)` in `/api/lists` and admin stats.
- **Free-form target names were silently discarded.** The upload form and iOS shortcut send `object_name`, but no column existed — a comet logged as "Comet Lemmon" kept no record of the name anywhere. New migration 15 adds `observations.object_name`, inserted on create, PATCH-editable, surfaced everywhere via `COALESCE(lo.name, o.object_name)`.
- **FITS metadata bugs:** zone-less `DATE-OBS` parsed as server-local time instead of UTC (hours-wrong `observed_at` on any non-UTC host); `APERTURE` (objective diameter in mm) stored where an f-number belongs, rendering "Aperture f/50.0" for an S50; escaped quotes (`''`) truncating header strings.
- **Clearing the default location planted uploads at Null Island** — `/api/settings` coerced the stored `''` with `Number('')` → `0,0`, which then auto-filled every EXIF-less upload. Cleared values now return `null`.
- **Upload form wiped NGC-fallback / manually-typed catalog ids at save time**, so IC targets and comet designations saved with NULL catalog fields and never ticked lists.
- **CSRF hardening (backlog #51):** admin write endpoints now reject requests whose `Origin` host doesn't match the request `Host`. Browsers attach cached Basic-Auth credentials to cross-site requests, so a hostile page could previously fire authenticated deletes. Origin-less clients (curl/scripts) are unaffected.

## Other fixes

**Server:** Seestar planner no longer truncates the night after a 1 h dry spell (backlog #49); observation delete removes files only after the DB transaction commits; `observed_at` validated on create; crossref `tol=0` honoured; stage response flags the real coordinate source.

**Upload flow:** sidecar JSON dropped with an image survives staging; telescope selection and `?object_id=` preselection survive batch-queue advances; save confirmation stays visible; browse picker accepts `.fits`/`.json`; drag highlight unsticks; weather auto-fetch debounced 750 ms (backlog #55); live "won't appear in planners" warning for free-form targets without RA/Dec (backlog #60).

**Public pages:** arrow-key nav no longer goes the wrong way at sequence ends; saved catalog filter applies to the auto-load on tonight/planner/seestar (DOM-state race); planner Object column sorts numerically; corrupt localStorage no longer kills tonight.js; lat/lon 0 keeps its map; configured site name is cached (no flash, backlog #58) and no longer clobbered by page-title writes; atlas wheel-zoom actually zooms (FOV-based); dim planner rows dim their links (#57); `.linkish` de-uppercased (#62).

**Robustness:** OCR init failure retries after a 10-min cooldown instead of disabling forever (backlog #56), recognize-timeouts terminate the stuck shared worker, and the uncaught-exception shim removes only its own listener; astrometry.net 200-with-HTML responses surface a readable error; edit modal accepts fractional exposures; ★ button hidden on rows it can never work for.

## Test plan

- `npm test` — 49 tests passing (44 existing + 5 new: CSRF origin checks, null default-location, Messier count stays 110, `object_name` round-trip, dark-moon events bracket real new moons).
- Manually verified against a live server: cross-origin write → 403, same-origin/curl → 200; cleared location → `null`; `tol=0` honoured; narrow-type Seestar plan runs to session end; ICS events land on the Jul 14 / Aug 13 2026 new moons.
- FITS parsing verified with a synthetic header under `TZ=America/Chicago` (UTC instant, unescaped quote, f/5 ratio all correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DR4HPiLEMWwseiWA4nU4E6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR4HPiLEMWwseiWA4nU4E6)_